### PR TITLE
Adding test and build workflow

### DIFF
--- a/.github/workflows/opensearch-querqy-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-querqy-test-and-build-workflow.yml
@@ -1,0 +1,40 @@
+name: Test and Build OpenSearch Querqy Plugin
+
+on: [pull_request, push]
+
+env:
+  OPENSEARCH_VERSION: '1.3.3'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        java:
+          - 8
+          - 11
+          - 14
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Build with Gradle
+        run: |
+          ./gradlew build -Dopensearch.version=${{ env.OPENSEARCH_VERSION }}
+
+      - name: Create Artifact Path
+        run: |
+          mkdir -p opensearch-querqy-builds
+          cp -r ./build/distributions/*.zip opensearch-querqy-builds/
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: opensearch-querqy
+          path: opensearch-querqy-builds


### PR DESCRIPTION
Added CI workflow to test and build querqy opensearch plugin. 
Added step to upload a zip artifact on successful build. 

resolves Issue: #15 

Signed-off-by: Shenoy Pratik <sgguruda@amazon.com>