### PR TITLE
Use SPI allowlist for QuerqyParserFactory instances

### DIFF
--- a/src/main/java/querqy/opensearch/ConfigUtils.java
+++ b/src/main/java/querqy/opensearch/ConfigUtils.java
@@ -22,13 +22,53 @@ package querqy.opensearch;
 import querqy.trie.TrieMap;
 
 import org.opensearch.secure_sm.AccessController;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public interface ConfigUtils {
 
+    Map<Class<?>, Set<String>> ALLOWED_INSTANCES_CACHE = new ConcurrentHashMap<>();
+
+    static <V> Set<String> loadAllowedInstances(final Class<V> type) {
+        return ALLOWED_INSTANCES_CACHE.computeIfAbsent(type, typeClass -> {
+            final String spiFile = "META-INF/services/" + typeClass.getName();
+            final ClassLoader cl = ConfigUtils.class.getClassLoader();
+            final Set<String> allowed = new HashSet<>();
+            try {
+                final Enumeration<URL> resources = cl.getResources(spiFile);
+                while (resources.hasMoreElements()) {
+                    try (BufferedReader reader = new BufferedReader(
+                            new InputStreamReader(resources.nextElement().openStream(), StandardCharsets.UTF_8))) {
+                        String line;
+                        while ((line = reader.readLine()) != null) {
+                            final int commentIdx = line.indexOf('#');
+                            if (commentIdx >= 0) {
+                                line = line.substring(0, commentIdx);
+                            }
+                            line = line.trim();
+                            if (!line.isEmpty()) {
+                                Class.forName(line, false, cl).asSubclass(typeClass);
+                                allowed.add(line);
+                            }
+                        }
+                    }
+                }
+            } catch (final Exception e) {
+                throw new RuntimeException("Failed to load service providers for " + typeClass.getName(), e);
+            }
+            return Collections.unmodifiableSet(allowed);
+        });
+    }
 
     static String getStringArg(final Map<String, Object> config, final String name, final String defaultValue) {
         final String value = (String) config.get(name);
@@ -63,7 +103,8 @@ public interface ConfigUtils {
     }
 
     @SuppressWarnings("unchecked")
-    static <V> V getInstanceFromArg(final Map<String, Object> config, final String name, final V defaultValue) {
+    static <V> V getInstanceFromArg(final Map<String, Object> config, final String name, final V defaultValue,
+                                    final Class<V> allowedType) {
         return AccessController.doPrivileged(
                 () -> {
                     final String classField = (String) config.get(name);
@@ -76,13 +117,18 @@ public interface ConfigUtils {
                         return defaultValue;
                     }
 
+                    if (!loadAllowedInstances(allowedType).contains(className)) {
+                        throw new IllegalArgumentException(
+                                "Class is not a registered " + allowedType.getSimpleName() +
+                                " service provider: " + className);
+                    }
+
                     try {
                         return (V) Class.forName(className).getConstructor().newInstance();
                     } catch (final Exception e) {
                         throw new RuntimeException(e);
                     }
-            });
-
+                });
     }
 
 }

--- a/src/main/java/querqy/opensearch/query/BoostingQueries.java
+++ b/src/main/java/querqy/opensearch/query/BoostingQueries.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/src/main/java/querqy/opensearch/rewriter/ReplaceRewriterFactory.java
+++ b/src/main/java/querqy/opensearch/rewriter/ReplaceRewriterFactory.java
@@ -62,7 +62,7 @@ public class ReplaceRewriterFactory extends OpenSearchRewriterFactory {
         final String inputDelimiter = ConfigUtils.getArg(config, "inputDelimiter", DEFAULT_INPUT_DELIMITER);
 
         final QuerqyParserFactory querqyParser = ConfigUtils.getInstanceFromArg(
-                config, "querqyParser", DEFAULT_RHS_QUERY_PARSER);
+                config, "querqyParser", DEFAULT_RHS_QUERY_PARSER, QuerqyParserFactory.class);
 
         try {
             delegate = new querqy.rewrite.contrib.ReplaceRewriterFactory(rewriterId, rulesReader, ignoreCase,
@@ -91,7 +91,7 @@ public class ReplaceRewriterFactory extends OpenSearchRewriterFactory {
 
         final QuerqyParserFactory querqyParser;
         try {
-            querqyParser = ConfigUtils.getInstanceFromArg(config, "querqyParser", DEFAULT_RHS_QUERY_PARSER);
+            querqyParser = ConfigUtils.getInstanceFromArg(config, "querqyParser", DEFAULT_RHS_QUERY_PARSER, QuerqyParserFactory.class);
         } catch (final Exception e) {
             return Collections.singletonList("Invalid attribute 'querqyParser': " + e.getMessage());
         }

--- a/src/main/java/querqy/opensearch/rewriter/SimpleCommonRulesRewriterFactory.java
+++ b/src/main/java/querqy/opensearch/rewriter/SimpleCommonRulesRewriterFactory.java
@@ -65,7 +65,7 @@ public class SimpleCommonRulesRewriterFactory extends OpenSearchRewriterFactory 
         final boolean allowBooleanInput = ConfigUtils.getArg(config, CONF_ALLOW_BOOLEAN_INPUT, false);
 
         final QuerqyParserFactory querqyParser = ConfigUtils
-                .getInstanceFromArg(config, CONF_RHS_QUERY_PARSER, DEFAULT_RHS_QUERY_PARSER);
+                .getInstanceFromArg(config, CONF_RHS_QUERY_PARSER, DEFAULT_RHS_QUERY_PARSER, QuerqyParserFactory.class);
 
         final String rules = ConfigUtils.getStringArg(config, CONF_RULES, "");
 
@@ -96,7 +96,7 @@ public class SimpleCommonRulesRewriterFactory extends OpenSearchRewriterFactory 
         final QuerqyParserFactory querqyParser;
         try {
             querqyParser = ConfigUtils
-                    .getInstanceFromArg(config, CONF_RHS_QUERY_PARSER, DEFAULT_RHS_QUERY_PARSER);
+                    .getInstanceFromArg(config, CONF_RHS_QUERY_PARSER, DEFAULT_RHS_QUERY_PARSER, QuerqyParserFactory.class);
         } catch (final Exception e) {
             return Collections.singletonList("Invalid attribute 'querqyParser': " + e.getMessage());
         }

--- a/src/main/resources/META-INF/services/querqy.rewrite.commonrules.QuerqyParserFactory
+++ b/src/main/resources/META-INF/services/querqy.rewrite.commonrules.QuerqyParserFactory
@@ -1,0 +1,2 @@
+querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory
+querqy.rewrite.commonrules.FieldAwareWhiteSpaceQuerqyParserFactory


### PR DESCRIPTION
This adds a new SPI file (META-INF/services/querqy.rewrite.commonrules.QuerqyParserFactory) and updated getInstanceFromArg to require an allowedType parameter, loading and checking the SPI allowlist for that type before calling Class.forName. All call sites in SimpleCommonRulesRewriterFactory and ReplaceRewriterFactory are updated to pass QuerqyParserFactory.class.