### PR TITLE
Migrate to OpenSearch 3.5.0

### DIFF
--- a/.github/workflows/opensearch-querqy-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-querqy-test-and-build-workflow.yml
@@ -4,7 +4,7 @@ on: [pull_request, push]
 
 env:
   PLUGIN_RELEASE_VERSION: '1.0'
-  OPENSEARCH_VERSION: '3.4.0'
+  OPENSEARCH_VERSION: '3.5.0'
 
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ opensearchplugin {
 buildscript {
 
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "3.4.0")
+        opensearch_version = System.getProperty("opensearch.version", "3.5.0")
     }
 
     repositories {


### PR DESCRIPTION
## Summary

- Bumps `opensearch_version` default from `3.4.0` to `3.5.0` in `build.gradle`
- Updates `OPENSEARCH_VERSION` in the CI workflow to `3.5.0`

OpenSearch 3.5.0 ships the same Lucene version (10.3.2) as 3.4.0, so no changes to `querqy-lucene` or other dependencies are required.

## Test plan

- [x] `./gradlew build` passes locally against 3.5.0 ✓
- [x] CI workflow runs against OpenSearch 3.5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)