### PR TITLE
Migrate to OpenSearch 3.6.0, querqy-lucene 5.11.lucene1040.0, querqy-core 4.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ opensearchplugin {
 buildscript {
 
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "3.5.0")
+        opensearch_version = System.getProperty("opensearch.version", "3.6.0")
     }
 
     repositories {
@@ -65,7 +65,7 @@ repositories {
 allprojects {
     group = "org.opensearch"
 
-    version = "1.2.os" + (opensearch_version - "-SNAPSHOT")
+    version = "1.3.os" + (opensearch_version - "-SNAPSHOT")
 
     if (isSnapshot) {
         version += "-SNAPSHOT"
@@ -84,8 +84,8 @@ allprojects {
 }
 
 dependencies {
-    api('org.querqy:querqy-lucene:5.9.lucene1032.0')
-    api("org.querqy:querqy-core:3.20.2")
+    api('org.querqy:querqy-lucene:5.11.lucene1040.0')
+    api("org.querqy:querqy-core:4.1.0")
     api('com.fasterxml.jackson.core:jackson-databind:2.22.0')
     api('com.fasterxml.jackson.core:jackson-annotations:2.22')
     implementation('com.jayway.jsonpath:json-path:3.0.0')

--- a/src/main/java/querqy/opensearch/rewriter/NumberUnitRewriterFactory.java
+++ b/src/main/java/querqy/opensearch/rewriter/NumberUnitRewriterFactory.java
@@ -25,9 +25,9 @@ import querqy.opensearch.rewriter.numberunit.NumberUnitConfigObject;
 import querqy.opensearch.rewriter.numberunit.NumberUnitConfigObject.NumberUnitDefinitionObject;
 import querqy.opensearch.rewriter.numberunit.NumberUnitQueryCreatorOpenSearch;
 import querqy.rewrite.RewriterFactory;
-import querqy.rewrite.contrib.numberunit.model.FieldDefinition;
-import querqy.rewrite.contrib.numberunit.model.NumberUnitDefinition;
-import querqy.rewrite.contrib.numberunit.model.UnitDefinition;
+import querqy.rewriter.numberunit.model.FieldDefinition;
+import querqy.rewriter.numberunit.model.NumberUnitDefinition;
+import querqy.rewriter.numberunit.model.UnitDefinition;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -72,7 +72,7 @@ public class NumberUnitRewriterFactory extends OpenSearchRewriterFactory {
 
     private static final String KEY_CONFIG_PROPERTY = "config";
 
-    private querqy.rewrite.contrib.NumberUnitRewriterFactory delegate;
+    private querqy.rewriter.numberunit.NumberUnitRewriterFactory delegate;
 
     public NumberUnitRewriterFactory(String rewriterId) {
         super(rewriterId);
@@ -100,7 +100,7 @@ public class NumberUnitRewriterFactory extends OpenSearchRewriterFactory {
         final int scale = getOrDefaultInt(numberUnitConfigObject::getScaleForLinearFunctions,
                 DEFAULT_SCALE_FOR_LINEAR_FUNCTIONS);
 
-        this.delegate = new querqy.rewrite.contrib.NumberUnitRewriterFactory(
+        this.delegate = new querqy.rewriter.numberunit.NumberUnitRewriterFactory(
                 rewriterId, parseConfig(numberUnitConfigObject), new NumberUnitQueryCreatorOpenSearch(scale));
 
     }

--- a/src/main/java/querqy/opensearch/rewriter/RegexReplaceRewriterFactory.java
+++ b/src/main/java/querqy/opensearch/rewriter/RegexReplaceRewriterFactory.java
@@ -39,7 +39,7 @@ public class RegexReplaceRewriterFactory  extends OpenSearchRewriterFactory {
     public static final String PROP_RULES = "rules";
     public static final String PROP_IGNORE_CASE = "ignoreCase";
 
-    private querqy.rewrite.replace.RegexReplaceRewriterFactory delegate;
+    private querqy.rewriter.regexreplace.RegexReplaceRewriterFactory delegate;
 
     public RegexReplaceRewriterFactory(final String rewriterId) {
         super(rewriterId);
@@ -56,7 +56,7 @@ public class RegexReplaceRewriterFactory  extends OpenSearchRewriterFactory {
         final boolean ignoreCase = ConfigUtils.getArg(config, PROP_IGNORE_CASE, DEFAULT_IGNORE_CASE);
 
         try {
-            delegate = new querqy.rewrite.replace.RegexReplaceRewriterFactory(rewriterId, rulesReader, ignoreCase);
+            delegate = new querqy.rewriter.regexreplace.RegexReplaceRewriterFactory(rewriterId, rulesReader, ignoreCase);
         } catch (final IOException e) {
             throw new OpenSearchException(e);
         }
@@ -76,7 +76,7 @@ public class RegexReplaceRewriterFactory  extends OpenSearchRewriterFactory {
         final boolean ignoreCase = ConfigUtils.getArg(config, PROP_IGNORE_CASE, DEFAULT_IGNORE_CASE);
 
         try {
-            new querqy.rewrite.replace.RegexReplaceRewriterFactory(rewriterId, rulesReader, ignoreCase);
+            new querqy.rewriter.regexreplace.RegexReplaceRewriterFactory(rewriterId, rulesReader, ignoreCase);
         } catch (final IOException e) {
             return Collections.singletonList("Cannot create rewriter: " + e.getMessage());
         }

--- a/src/main/java/querqy/opensearch/rewriter/ReplaceRewriterFactory.java
+++ b/src/main/java/querqy/opensearch/rewriter/ReplaceRewriterFactory.java
@@ -23,8 +23,8 @@ import org.opensearch.index.shard.IndexShard;
 import querqy.opensearch.ConfigUtils;
 import querqy.opensearch.OpenSearchRewriterFactory;
 import querqy.rewrite.RewriterFactory;
-import querqy.rewrite.commonrules.QuerqyParserFactory;
-import querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory;
+import querqy.rewriter.commonrules.QuerqyParserFactory;
+import querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -42,7 +42,7 @@ public class ReplaceRewriterFactory extends OpenSearchRewriterFactory {
 
     private static final String DEFAULT_INPUT_DELIMITER = "\t";
 
-    private querqy.rewrite.contrib.ReplaceRewriterFactory delegate;
+    private querqy.rewriter.replace.ReplaceRewriterFactory delegate;
 
     public ReplaceRewriterFactory(String rewriterId) {
         super(rewriterId);
@@ -64,7 +64,7 @@ public class ReplaceRewriterFactory extends OpenSearchRewriterFactory {
                 config, "querqyParser", DEFAULT_RHS_QUERY_PARSER, QuerqyParserFactory.class);
 
         try {
-            delegate = new querqy.rewrite.contrib.ReplaceRewriterFactory(rewriterId, rulesReader, ignoreCase,
+            delegate = new querqy.rewriter.replace.ReplaceRewriterFactory(rewriterId, rulesReader, ignoreCase,
                     inputDelimiter, querqyParser.createParser());
         } catch (final IOException e) {
             throw new OpenSearchException(e);
@@ -96,7 +96,7 @@ public class ReplaceRewriterFactory extends OpenSearchRewriterFactory {
         }
 
         try {
-            new querqy.rewrite.contrib.ReplaceRewriterFactory(rewriterId, rulesReader, ignoreCase, inputDelimiter,
+            new querqy.rewriter.replace.ReplaceRewriterFactory(rewriterId, rulesReader, ignoreCase, inputDelimiter,
                     querqyParser.createParser());
         } catch (final IOException e) {
             return Collections.singletonList("Cannot create rewriter: " + e.getMessage());

--- a/src/main/java/querqy/opensearch/rewriter/SimpleCommonRulesRewriterFactory.java
+++ b/src/main/java/querqy/opensearch/rewriter/SimpleCommonRulesRewriterFactory.java
@@ -23,11 +23,11 @@ import org.opensearch.index.shard.IndexShard;
 import querqy.opensearch.ConfigUtils;
 import querqy.opensearch.OpenSearchRewriterFactory;
 import querqy.rewrite.RewriterFactory;
-import querqy.rewrite.commonrules.QuerqyParserFactory;
-import querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory;
-import querqy.rewrite.commonrules.model.BoostInstruction.BoostMethod;
-import querqy.rewrite.commonrules.select.ExpressionCriteriaSelectionStrategyFactory;
-import querqy.rewrite.commonrules.select.SelectionStrategyFactory;
+import querqy.rewriter.commonrules.QuerqyParserFactory;
+import querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory;
+import querqy.rewriter.commonrules.model.BoostInstruction.BoostMethod;
+import querqy.rewriter.commonrules.select.ExpressionCriteriaSelectionStrategyFactory;
+import querqy.rewriter.commonrules.select.SelectionStrategyFactory;
 import querqy.rewrite.lookup.preprocessing.LookupPreprocessorType;
 
 import java.io.IOException;
@@ -52,7 +52,7 @@ public class SimpleCommonRulesRewriterFactory extends OpenSearchRewriterFactory 
 
     static final LookupPreprocessorType DEFAULT_LOOKUP_PREPROCESSOR_TYPE = LookupPreprocessorType.LOWERCASE;
 
-    private querqy.rewrite.commonrules.SimpleCommonRulesRewriterFactory delegate;
+    private querqy.rewriter.commonrules.SimpleCommonRulesRewriterFactory delegate;
 
     public SimpleCommonRulesRewriterFactory(final String rewriterId) {
         super(rewriterId);
@@ -76,7 +76,7 @@ public class SimpleCommonRulesRewriterFactory extends OpenSearchRewriterFactory 
                 .orElse(DEFAULT_LOOKUP_PREPROCESSOR_TYPE);
 
         try {
-            delegate = new querqy.rewrite.commonrules.SimpleCommonRulesRewriterFactory(rewriterId,
+            delegate = new querqy.rewriter.commonrules.SimpleCommonRulesRewriterFactory(rewriterId,
                     new StringReader(rules), allowBooleanInput, BoostMethod.ADDITIVE,
                     querqyParser, selectionStrategyFactories,
                     DEFAULT_SELECTION_STRATEGY_FACTORY, false, lookupPreprocessorType);
@@ -110,7 +110,7 @@ public class SimpleCommonRulesRewriterFactory extends OpenSearchRewriterFactory 
                 .map(LookupPreprocessorType::fromString)
                 .orElse(DEFAULT_LOOKUP_PREPROCESSOR_TYPE);
         try {
-            new querqy.rewrite.commonrules.SimpleCommonRulesRewriterFactory(rewriterId,
+            new querqy.rewriter.commonrules.SimpleCommonRulesRewriterFactory(rewriterId,
                     new StringReader(rules), allowBooleanInput, BoostMethod.ADDITIVE,querqyParser,
                     Collections.emptyMap(),
                     DEFAULT_SELECTION_STRATEGY_FACTORY, false, lookupPreprocessorType);

--- a/src/main/java/querqy/opensearch/rewriter/WordBreakCompoundRewriterFactory.java
+++ b/src/main/java/querqy/opensearch/rewriter/WordBreakCompoundRewriterFactory.java
@@ -18,8 +18,7 @@
 
 package querqy.opensearch.rewriter;
 
-import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.search.spell.WordBreakSpellChecker;
+import querqy.lucene.LuceneTermCorpus;
 import querqy.opensearch.DismaxSearchEngineRequestAdapter;
 import org.opensearch.index.shard.IndexShard;
 import querqy.opensearch.ConfigUtils;
@@ -28,13 +27,11 @@ import querqy.model.ExpandedQuery;
 import querqy.model.Term;
 import querqy.rewrite.QueryRewriter;
 import querqy.rewrite.RewriterFactory;
-import querqy.lucene.contrib.rewrite.wordbreak.LuceneCompounder;
-import querqy.lucene.contrib.rewrite.wordbreak.MorphologicalCompounder;
-import querqy.lucene.contrib.rewrite.wordbreak.MorphologicalWordBreaker;
-import querqy.lucene.contrib.rewrite.wordbreak.Morphology;
-import querqy.lucene.contrib.rewrite.wordbreak.MorphologyProvider;
-import querqy.lucene.contrib.rewrite.wordbreak.SpellCheckerCompounder;
-import querqy.lucene.contrib.rewrite.wordbreak.WordBreakCompoundRewriter;
+import querqy.rewriter.wordbreak.MorphologicalCompounder;
+import querqy.rewriter.wordbreak.MorphologicalWordBreaker;
+import querqy.rewriter.wordbreak.Morphology;
+import querqy.rewriter.wordbreak.MorphologyProvider;
+import querqy.rewriter.wordbreak.WordBreakCompoundRewriter;
 import querqy.rewrite.SearchEngineRequestAdapter;
 import querqy.trie.TrieMap;
 
@@ -46,16 +43,6 @@ import java.util.Optional;
 import java.util.Set;
 
 public class WordBreakCompoundRewriterFactory extends OpenSearchRewriterFactory {
-
-    // this controls behaviour of the Lucene WordBreakSpellChecker:
-    // for compounds: maximum distance of leftmost and rightmost term index
-    //                e.g. max_changes = 1 for A B C D will check AB BC CD,
-    //                     max_changes = 2 for A B C D will check AB ABC BC BCD CD
-    // for decompounds: maximum splits performed
-    //                  e.g. max_changes = 1 for ABCD will check A BCD, AB CD, ABC D,
-    //                       max_changes = 2 for ABCD will check A BCD, A B CD, A BC D, AB CD, AB C D, ABC D
-    // as we currently only send 2-grams to WBSP for compounding only max_changes = 1 is correctly supported
-    static final int MAX_CHANGES = 1;
 
     static final int MAX_EVALUATIONS = 100;
 
@@ -69,21 +56,16 @@ public class WordBreakCompoundRewriterFactory extends OpenSearchRewriterFactory 
     static final String DEFAULT_MORPHOLOGY_NAME = "DEFAULT";
     private static final MorphologyProvider MORPHOLOGY_PROVIDER = new MorphologyProvider();
 
-
     private String dictionaryField;
-
     private boolean lowerCaseInput = DEFAULT_LOWER_CASE_INPUT;
     private boolean alwaysAddReverseCompounds = DEFAULT_ALWAYS_ADD_REVERSE_COMPOUNDS;
-
-    private WordBreakSpellChecker spellChecker;
-    private LuceneCompounder compounder;
+    private MorphologicalCompounder compounder;
     private MorphologicalWordBreaker wordBreaker;
     private TrieMap<Boolean> reverseCompoundTriggerWords;
     private TrieMap<Boolean> protectedWords;
     private int maxDecompoundExpansions = DEFAULT_MAX_DECOMPOUND_EXPANSIONS;
     private boolean verifyDecompoundCollation = DEFAULT_VERIFY_DECOMPOUND_COLLATION;
-
-
+    private int minSuggestionFreq = DEFAULT_MIN_SUGGESTION_FREQ;
 
     public WordBreakCompoundRewriterFactory(final String rewriterId) {
         super(rewriterId);
@@ -92,8 +74,7 @@ public class WordBreakCompoundRewriterFactory extends OpenSearchRewriterFactory 
     @Override
     public void configure(final Map<String, Object> config) {
 
-        final int minSuggestionFreq = ConfigUtils.getArg(config, "minSuggestionFreq", DEFAULT_MIN_SUGGESTION_FREQ);
-        final int maxCombineLength = ConfigUtils.getArg(config, "maxCombineLength", DEFAULT_MAX_COMBINE_LENGTH);
+        minSuggestionFreq = ConfigUtils.getArg(config, "minSuggestionFreq", DEFAULT_MIN_SUGGESTION_FREQ);
         final int minBreakLength = ConfigUtils.getArg(config, "minBreakLength", DEFAULT_MIN_BREAK_LENGTH);
         dictionaryField = ConfigUtils.getStringArg(config, "dictionaryField")
                 .map(String::trim)
@@ -103,14 +84,8 @@ public class WordBreakCompoundRewriterFactory extends OpenSearchRewriterFactory 
         alwaysAddReverseCompounds = ConfigUtils.getArg(config, "alwaysAddReverseCompounds",
                 DEFAULT_ALWAYS_ADD_REVERSE_COMPOUNDS);
 
-        spellChecker = new WordBreakSpellChecker();
-        spellChecker.setMaxChanges(MAX_CHANGES);
-        spellChecker.setMinSuggestionFrequency(minSuggestionFreq);
-        spellChecker.setMaxCombineWordLength(maxCombineLength);
-        spellChecker.setMinBreakWordLength(minBreakLength);
-        spellChecker.setMaxEvaluations(100);
-
         final String defaultMorphologyName = ConfigUtils.getStringArg(config, "morphology", DEFAULT_MORPHOLOGY_NAME);
+
         Map<String, Object> compoundConf = (Map<String, Object>) config.get("compound");
         if (compoundConf == null) {
             compoundConf = Collections.emptyMap();
@@ -118,20 +93,8 @@ public class WordBreakCompoundRewriterFactory extends OpenSearchRewriterFactory 
         final String compoundMorphologyName = ConfigUtils.getStringArg(compoundConf, "morphology",
                 defaultMorphologyName);
         final Optional<Morphology> compoundMorphology = MORPHOLOGY_PROVIDER.get(compoundMorphologyName);
-        if (compoundMorphology.isEmpty() || compoundMorphology.get() == MorphologyProvider.DEFAULT) {
-            // use WordBreakSpellChecker when DEFAULT for backwards compatibility
-            final WordBreakSpellChecker spellChecker = new WordBreakSpellChecker();
-            spellChecker.setMaxChanges(MAX_CHANGES);
-            spellChecker.setMinSuggestionFrequency(minSuggestionFreq);
-            spellChecker.setMaxCombineWordLength(maxCombineLength);
-            spellChecker.setMinBreakWordLength(minBreakLength);
-            spellChecker.setMaxEvaluations(100);
-            compounder = new SpellCheckerCompounder(spellChecker, dictionaryField, lowerCaseInput);
-        } else {
-            compounder = new MorphologicalCompounder(compoundMorphology.get(), dictionaryField, lowerCaseInput,
-                    minSuggestionFreq);
-        }
-
+        compounder = new MorphologicalCompounder(
+                compoundMorphology.orElse(MorphologyProvider.DEFAULT), lowerCaseInput, minSuggestionFreq);
 
         Map<String, Object> decompoundConf = (Map<String, Object>) config.get("decompound");
         if (decompoundConf == null) {
@@ -140,13 +103,15 @@ public class WordBreakCompoundRewriterFactory extends OpenSearchRewriterFactory 
         final String decompoundMorphologyName = ConfigUtils.getStringArg(decompoundConf, "morphology",
                 defaultMorphologyName);
         final Optional<Morphology> decompoundMorphology = MORPHOLOGY_PROVIDER.get(decompoundMorphologyName);
-        wordBreaker = new MorphologicalWordBreaker(decompoundMorphology.get(), dictionaryField, lowerCaseInput,
+        wordBreaker = new MorphologicalWordBreaker(
+                decompoundMorphology.orElse(MorphologyProvider.DEFAULT), lowerCaseInput,
                 minSuggestionFreq, minBreakLength, MAX_EVALUATIONS);
+
         reverseCompoundTriggerWords = ConfigUtils.getTrieSetArg(config, "reverseCompoundTriggerWords");
         protectedWords = ConfigUtils.getTrieSetArg(config, "protectedWords");
         maxDecompoundExpansions = ConfigUtils.getArg(decompoundConf, "maxExpansions",
                 DEFAULT_MAX_DECOMPOUND_EXPANSIONS);
-        verifyDecompoundCollation =  ConfigUtils.getArg(decompoundConf, "verifyCollation",
+        verifyDecompoundCollation = ConfigUtils.getArg(decompoundConf, "verifyCollation",
                 DEFAULT_VERIFY_DECOMPOUND_COLLATION);
     }
 
@@ -184,7 +149,6 @@ public class WordBreakCompoundRewriterFactory extends OpenSearchRewriterFactory 
         }
 
         return errors;
-
     }
 
     @Override
@@ -195,14 +159,15 @@ public class WordBreakCompoundRewriterFactory extends OpenSearchRewriterFactory 
             public QueryRewriter createRewriter(final ExpandedQuery input,
                                                 final SearchEngineRequestAdapter searchEngineRequestAdapter) {
 
+                final DismaxSearchEngineRequestAdapter adapter =
+                        (DismaxSearchEngineRequestAdapter) searchEngineRequestAdapter;
+                final LuceneTermCorpus corpus = new LuceneTermCorpus(
+                        () -> adapter.getSearchExecutionContext().searcher().getTopReaderContext().reader(),
+                        dictionaryField);
 
-
-                return new WordBreakCompoundRewriter(wordBreaker, compounder,
-                        getShardIndexReader((DismaxSearchEngineRequestAdapter) searchEngineRequestAdapter),
-                        lowerCaseInput, alwaysAddReverseCompounds, reverseCompoundTriggerWords, maxDecompoundExpansions,
-                        verifyDecompoundCollation, protectedWords);
-
-
+                return new WordBreakCompoundRewriter(wordBreaker, compounder, corpus,
+                        lowerCaseInput, alwaysAddReverseCompounds, reverseCompoundTriggerWords,
+                        maxDecompoundExpansions, verifyDecompoundCollation, protectedWords);
             }
 
             @Override
@@ -212,14 +177,9 @@ public class WordBreakCompoundRewriterFactory extends OpenSearchRewriterFactory 
         };
     }
 
-    public WordBreakSpellChecker getSpellChecker() {
-        return spellChecker;
-    }
-
     public String getDictionaryField() {
         return dictionaryField;
     }
-
 
     public boolean isLowerCaseInput() {
         return lowerCaseInput;
@@ -245,17 +205,11 @@ public class WordBreakCompoundRewriterFactory extends OpenSearchRewriterFactory 
         return verifyDecompoundCollation;
     }
 
-    private IndexReader getShardIndexReader(final DismaxSearchEngineRequestAdapter searchEngineRequestAdapter) {
-        return searchEngineRequestAdapter.getSearchExecutionContext().searcher().getTopReaderContext().reader();
-    }
-
-    public LuceneCompounder getCompounder() {
+    public MorphologicalCompounder getCompounder() {
         return compounder;
     }
 
     public MorphologicalWordBreaker getWordBreaker() {
         return wordBreaker;
     }
-
-
 }

--- a/src/main/java/querqy/opensearch/rewriter/numberunit/NumberUnitQueryCreatorOpenSearch.java
+++ b/src/main/java/querqy/opensearch/rewriter/numberunit/NumberUnitQueryCreatorOpenSearch.java
@@ -30,9 +30,9 @@ import querqy.opensearch.query.QueryBuilderRawQuery;
 import querqy.model.BoostQuery;
 import querqy.model.Clause;
 import querqy.model.RawQuery;
-import querqy.rewrite.contrib.numberunit.NumberUnitQueryCreator;
-import querqy.rewrite.contrib.numberunit.model.NumberUnitDefinition;
-import querqy.rewrite.contrib.numberunit.model.PerUnitNumberUnitDefinition;
+import querqy.rewriter.numberunit.NumberUnitQueryCreator;
+import querqy.rewriter.numberunit.model.NumberUnitDefinition;
+import querqy.rewriter.numberunit.model.PerUnitNumberUnitDefinition;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;

--- a/src/main/resources/META-INF/services/querqy.rewrite.commonrules.QuerqyParserFactory
+++ b/src/main/resources/META-INF/services/querqy.rewrite.commonrules.QuerqyParserFactory
@@ -1,2 +1,0 @@
-querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory
-querqy.rewrite.commonrules.FieldAwareWhiteSpaceQuerqyParserFactory

--- a/src/main/resources/META-INF/services/querqy.rewriter.commonrules.QuerqyParserFactory
+++ b/src/main/resources/META-INF/services/querqy.rewriter.commonrules.QuerqyParserFactory
@@ -1,0 +1,2 @@
+querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory
+querqy.rewriter.commonrules.FieldAwareWhiteSpaceQuerqyParserFactory

--- a/src/test/java/querqy/opensearch/QuerqyMappingsUpdate1To3IntegrationTest.java
+++ b/src/test/java/querqy/opensearch/QuerqyMappingsUpdate1To3IntegrationTest.java
@@ -87,7 +87,7 @@ public class QuerqyMappingsUpdate1To3IntegrationTest extends OpenSearchSingleNod
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "k =>\nSYNONYM: c\n@_log: \"msg1\"");
         config.put("ignoreCase", true);
-        config.put("querqyParser", querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
+        config.put("querqyParser", querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
         content.put("config", config);
 
         client().execute(PutRewriterAction.INSTANCE, new PutRewriterRequest("common_rules", content)).get();

--- a/src/test/java/querqy/opensearch/QuerqyMappingsUpdate2To3IntegrationTest.java
+++ b/src/test/java/querqy/opensearch/QuerqyMappingsUpdate2To3IntegrationTest.java
@@ -91,7 +91,7 @@ public class QuerqyMappingsUpdate2To3IntegrationTest extends OpenSearchSingleNod
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "k =>\nSYNONYM: c\n@_log: \"msg1\"");
         config.put("ignoreCase", true);
-        config.put("querqyParser", querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
+        config.put("querqyParser", querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
         content.put("config", config);
 
         client().execute(PutRewriterAction.INSTANCE, new PutRewriterRequest("common_rules", content)).get();

--- a/src/test/java/querqy/opensearch/RewriterIntegrationTest.java
+++ b/src/test/java/querqy/opensearch/RewriterIntegrationTest.java
@@ -67,7 +67,7 @@ public class RewriterIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "k =>\nSYNONYM: c");
         config.put("ignoreCase", true);
-        config.put("querqyParser", querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
+        config.put("querqyParser", querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);
@@ -95,7 +95,7 @@ public class RewriterIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "a =>\nFILTER: * {\"term\":{\"field2\":\"c\" }}");
         config.put("ignoreCase", true);
-        config.put("querqyParser", querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
+        config.put("querqyParser", querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
         content.put("config", config);
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);
         client().execute(PutRewriterAction.INSTANCE, request).get();
@@ -128,7 +128,7 @@ public class RewriterIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", rules);
         config.put("ignoreCase", true);
-        config.put("querqyParser", querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
+        config.put("querqyParser", querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);
@@ -149,7 +149,7 @@ public class RewriterIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "");
         config.put("ignoreCase", true);
-        config.put("querqyParser", querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
+        config.put("querqyParser", querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);
@@ -174,7 +174,7 @@ public class RewriterIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config2 = new HashMap<>();
         config2.put("rules", "k =>\nSYNONYM: c");
         config2.put("ignoreCase", true);
-        config2.put("querqyParser", querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
+        config2.put("querqyParser", querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
         content2.put("config", config2);
 
         final PutRewriterRequest request2 = new PutRewriterRequest("common_rules", content2);
@@ -205,7 +205,7 @@ public class RewriterIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "k =>\nSYNONYM: c");
         config.put("ignoreCase", true);
-        config.put("querqyParser", querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
+        config.put("querqyParser", querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);

--- a/src/test/java/querqy/opensearch/infologging/InfoLoggingIntegrationTest.java
+++ b/src/test/java/querqy/opensearch/infologging/InfoLoggingIntegrationTest.java
@@ -118,7 +118,7 @@ public class InfoLoggingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "k =>\nSYNONYM: c\n@_log: \"msg1\"");
         config.put("ignoreCase", true);
-        config.put("querqyParser", querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
+        config.put("querqyParser", querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);
@@ -162,7 +162,7 @@ public class InfoLoggingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "k =>\nSYNONYM: c\n@_log: \"msg1\"");
         config.put("ignoreCase", true);
-        config.put("querqyParser", querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
+        config.put("querqyParser", querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);
@@ -189,7 +189,7 @@ public class InfoLoggingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config1 = new HashMap<>();
         config1.put("rules", "k =>\nSYNONYM: c\n@_log: \"msg1\"");
         config1.put("ignoreCase", true);
-        config1.put("querqyParser", querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
+        config1.put("querqyParser", querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
         content1.put("config", config1);
 
         final PutRewriterRequest request1 = new PutRewriterRequest("common_rules1", content1);
@@ -205,7 +205,7 @@ public class InfoLoggingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config2 = new HashMap<>();
         config2.put("rules", "k =>\nUP: q\n@_log: \"msg2\"");
         config2.put("ignoreCase", true);
-        config2.put("querqyParser", querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
+        config2.put("querqyParser", querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
         content2.put("config", config2);
 
         final PutRewriterRequest request2 = new PutRewriterRequest("common_rules2", content2);
@@ -266,7 +266,7 @@ public class InfoLoggingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config2 = new HashMap<>();
         config2.put("rules", "k =>\nSYNONYM: c\n@_log: \"msg2\"");
         config2.put("ignoreCase", true);
-        config2.put("querqyParser", querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
+        config2.put("querqyParser", querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
         content2.put("config", config2);
 
         final PutRewriterRequest request2 = new PutRewriterRequest("common_rules2", content2);
@@ -313,7 +313,7 @@ public class InfoLoggingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config1 = new HashMap<>();
         config1.put("rules", "k =>\nSYNONYM: c\n@_log: \"msg1\"");
         config1.put("ignoreCase", true);
-        config1.put("querqyParser", querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
+        config1.put("querqyParser", querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
         content1.put("config", config1);
 
         final PutRewriterRequest request1 = new PutRewriterRequest("common_rules1", content1);
@@ -350,7 +350,7 @@ public class InfoLoggingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "k =>\nSYNONYM: c\n@_log: \"msg1\"");
         config.put("ignoreCase", true);
-        config.put("querqyParser", querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
+        config.put("querqyParser", querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);
@@ -393,7 +393,7 @@ public class InfoLoggingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "k =>\nSYNONYM: c\n@_log: \"msg1\"");
         config.put("ignoreCase", true);
-        config.put("querqyParser", querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
+        config.put("querqyParser", querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);
@@ -436,7 +436,7 @@ public class InfoLoggingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config1 = new HashMap<>();
         config1.put("rules", "k =>\nSYNONYM: c\n@_log: \"msg1\"");
         config1.put("ignoreCase", true);
-        config1.put("querqyParser", querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
+        config1.put("querqyParser", querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
         content1.put("config", config1);
 
         final PutRewriterRequest request1 = new PutRewriterRequest("common_rules1", content1);
@@ -452,7 +452,7 @@ public class InfoLoggingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config2 = new HashMap<>();
         config2.put("rules", "k =>\nUP: q\n@_log: \"msg2\"");
         config2.put("ignoreCase", true);
-        config2.put("querqyParser", querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
+        config2.put("querqyParser", querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
         content2.put("config", config2);
 
         final PutRewriterRequest request2 = new PutRewriterRequest("common_rules2", content2);

--- a/src/test/java/querqy/opensearch/infologging/InfoLoggingMultiShardIntegrationTest.java
+++ b/src/test/java/querqy/opensearch/infologging/InfoLoggingMultiShardIntegrationTest.java
@@ -147,7 +147,7 @@ public class InfoLoggingMultiShardIntegrationTest extends OpenSearchIntegTestCas
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "k =>\nSYNONYM: c\n@_log: \"msg1\"");
         config.put("ignoreCase", true);
-        config.put("querqyParser", querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
+        config.put("querqyParser", querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);

--- a/src/test/java/querqy/opensearch/query/QueryBuildingIntegrationTest.java
+++ b/src/test/java/querqy/opensearch/query/QueryBuildingIntegrationTest.java
@@ -56,7 +56,7 @@ public class QueryBuildingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "cc =>\nUP(1000): -aa");
         config.put("ignoreCase", true);
-        config.put("querqyParser", "querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory");
+        config.put("querqyParser", "querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory");
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);
@@ -91,7 +91,7 @@ public class QueryBuildingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "cc =>\nUP(1000): -aa -bb");
         config.put("ignoreCase", true);
-        config.put("querqyParser", "querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory");
+        config.put("querqyParser", "querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory");
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);
@@ -126,7 +126,7 @@ public class QueryBuildingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "cc =>\nUP(1000): kk");
         config.put("ignoreCase", true);
-        config.put("querqyParser", "querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory");
+        config.put("querqyParser", "querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory");
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);
@@ -161,7 +161,7 @@ public class QueryBuildingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "cc =>\nUP(1000): kk jj");
         config.put("ignoreCase", true);
-        config.put("querqyParser", "querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory");
+        config.put("querqyParser", "querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory");
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);
@@ -196,7 +196,7 @@ public class QueryBuildingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "cc =>\nDOWN(1000): aa bb");
         config.put("ignoreCase", true);
-        config.put("querqyParser", "querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory");
+        config.put("querqyParser", "querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory");
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);
@@ -232,7 +232,7 @@ public class QueryBuildingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "cc =>\nUP(1000): kk -aa");
         config.put("ignoreCase", true);
-        config.put("querqyParser", "querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory");
+        config.put("querqyParser", "querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory");
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);
@@ -267,7 +267,7 @@ public class QueryBuildingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "cc =>\nUP(1000): -aa\nUP(1000): -bb");
         config.put("ignoreCase", true);
-        config.put("querqyParser", "querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory");
+        config.put("querqyParser", "querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory");
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);
@@ -302,7 +302,7 @@ public class QueryBuildingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "cc =>\nFILTER: -aa");
         config.put("ignoreCase", true);
-        config.put("querqyParser", "querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory");
+        config.put("querqyParser", "querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory");
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);
@@ -337,7 +337,7 @@ public class QueryBuildingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "cc =>\nFILTER: -ii -jj");
         config.put("ignoreCase", true);
-        config.put("querqyParser", "querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory");
+        config.put("querqyParser", "querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory");
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);
@@ -372,7 +372,7 @@ public class QueryBuildingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "cc =>\nUP(1000): *{\"term\": {\"field1\":\"ii\"}}");
         config.put("ignoreCase", true);
-        config.put("querqyParser", "querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory");
+        config.put("querqyParser", "querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory");
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);
@@ -407,7 +407,7 @@ public class QueryBuildingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "cc =>\nDOWN(1000): *{\"term\": {\"field1\":\"bb\"}}");
         config.put("ignoreCase", true);
-        config.put("querqyParser", "querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory");
+        config.put("querqyParser", "querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory");
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);
@@ -442,7 +442,7 @@ public class QueryBuildingIntegrationTest extends OpenSearchSingleNodeTestCase {
         final Map<String, Object> config = new HashMap<>();
         config.put("rules", "cc =>\nFILTER: *{\"term\": {\"field1\":\"ii\"}}");
         config.put("ignoreCase", true);
-        config.put("querqyParser", "querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory");
+        config.put("querqyParser", "querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory");
         content.put("config", config);
 
         final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);

--- a/src/test/java/querqy/opensearch/rewriter/NumberUnitRewriterParseConfigTest.java
+++ b/src/test/java/querqy/opensearch/rewriter/NumberUnitRewriterParseConfigTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.Matchers.empty;
 import org.opensearch.test.OpenSearchTestCase;
 
 import querqy.opensearch.rewriter.numberunit.NumberUnitConfigObject;
-import querqy.rewrite.contrib.numberunit.model.NumberUnitDefinition;
+import querqy.rewriter.numberunit.model.NumberUnitDefinition;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/test/java/querqy/opensearch/rewriter/WordBreakCompoundRewriterFactoryTest.java
+++ b/src/test/java/querqy/opensearch/rewriter/WordBreakCompoundRewriterFactoryTest.java
@@ -25,11 +25,9 @@ import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.eq;
 import static querqy.opensearch.rewriter.WordBreakCompoundRewriterFactory.DEFAULT_ALWAYS_ADD_REVERSE_COMPOUNDS;
 import static querqy.opensearch.rewriter.WordBreakCompoundRewriterFactory.DEFAULT_LOWER_CASE_INPUT;
-import static querqy.opensearch.rewriter.WordBreakCompoundRewriterFactory.DEFAULT_MAX_COMBINE_LENGTH;
 import static querqy.opensearch.rewriter.WordBreakCompoundRewriterFactory.DEFAULT_MIN_BREAK_LENGTH;
 import static querqy.opensearch.rewriter.WordBreakCompoundRewriterFactory.DEFAULT_MIN_SUGGESTION_FREQ;
 import static querqy.opensearch.rewriter.WordBreakCompoundRewriterFactory.DEFAULT_VERIFY_DECOMPOUND_COLLATION;
-import static querqy.opensearch.rewriter.WordBreakCompoundRewriterFactory.MAX_CHANGES;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
@@ -38,14 +36,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-//<<<<<<< HEAD
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.IndexReaderContext;
-import org.apache.lucene.search.spell.WordBreakSpellChecker;
 import org.apache.lucene.search.IndexSearcher;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.index.query.QueryShardContext;
+import querqy.lucene.LuceneTermCorpus;
 import querqy.opensearch.DismaxSearchEngineRequestAdapter;
 import org.opensearch.index.shard.IndexShard;
 import org.hamcrest.Matchers;
@@ -53,9 +50,9 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.index.TermsEnum;
-import querqy.lucene.contrib.rewrite.wordbreak.LuceneCompounder;
-import querqy.lucene.contrib.rewrite.wordbreak.MorphologicalWordBreaker;
-import querqy.lucene.contrib.rewrite.wordbreak.WordBreakCompoundRewriter;
+import querqy.rewriter.wordbreak.MorphologicalCompounder;
+import querqy.rewriter.wordbreak.MorphologicalWordBreaker;
+import querqy.rewriter.wordbreak.WordBreakCompoundRewriter;
 import querqy.rewrite.RewriterFactory;
 import querqy.trie.TrieMap;
 import static org.mockito.Mockito.withSettings;
@@ -113,16 +110,10 @@ public class WordBreakCompoundRewriterFactoryTest extends OpenSearchTestCase {
 
         final WordBreakCompoundRewriterFactory factory = new WordBreakCompoundRewriterFactory("r1");
         factory.configure(Collections.singletonMap("dictionaryField", "f1"));
-        final WordBreakSpellChecker spellChecker = factory.getSpellChecker();
-        assertNotNull(spellChecker);
-        assertEquals(MAX_CHANGES, spellChecker.getMaxChanges());
-        assertEquals(DEFAULT_MAX_COMBINE_LENGTH, spellChecker.getMaxCombineWordLength());
-        assertEquals(DEFAULT_MIN_SUGGESTION_FREQ, spellChecker.getMinSuggestionFrequency());
-        assertEquals(DEFAULT_MIN_BREAK_LENGTH, spellChecker.getMinBreakWordLength());
+
         assertEquals(DEFAULT_LOWER_CASE_INPUT, factory.isLowerCaseInput());
         assertEquals(DEFAULT_ALWAYS_ADD_REVERSE_COMPOUNDS, factory.isAlwaysAddReverseCompounds());
         assertEquals(DEFAULT_VERIFY_DECOMPOUND_COLLATION, factory.isVerifyDecompoundCollation());
-
         assertEquals("f1", factory.getDictionaryField());
 
         assertNotNull(factory.getCompounder());
@@ -159,7 +150,8 @@ public class WordBreakCompoundRewriterFactoryTest extends OpenSearchTestCase {
 
         when(mockTermsEnum.docFreq()).thenAnswer(invocation -> freqMap.get(currentTerm[0]));
 
-        wordBreaker.breakWord("abcdef", indexReader, 2, true);
+        final LuceneTermCorpus corpus = new LuceneTermCorpus(() -> indexReader, "f1");
+        wordBreaker.breakWord("abcdef", corpus, 2, false);
         verify(mockTermsEnum, times(1)).seekExact(eq(new BytesRef("def")));
         verify(mockTermsEnum, times(1)).seekExact(eq(new BytesRef("abc")));
 
@@ -193,12 +185,6 @@ public class WordBreakCompoundRewriterFactoryTest extends OpenSearchTestCase {
         final WordBreakCompoundRewriterFactory factory = new WordBreakCompoundRewriterFactory("r1");
         factory.configure(config);
 
-        final WordBreakSpellChecker spellChecker = factory.getSpellChecker();
-        assertNotNull(spellChecker);
-
-        assertEquals(22, spellChecker.getMaxCombineWordLength());
-        assertEquals(11, spellChecker.getMinSuggestionFrequency());
-        assertEquals(1, spellChecker.getMinBreakWordLength());
         assertEquals(87, factory.getMaxDecompoundExpansions());
 
         assertNotEquals(DEFAULT_LOWER_CASE_INPUT, factory.isLowerCaseInput());
@@ -247,7 +233,8 @@ public class WordBreakCompoundRewriterFactoryTest extends OpenSearchTestCase {
 
         when(mockTermsEnum.docFreq()).thenAnswer(invocation -> freqMap.get(currentTerm[0]));
 
-        wordBreaker.breakWord("abcde", indexReader, 2, true);
+        final LuceneTermCorpus corpus = new LuceneTermCorpus(() -> indexReader, "f2");
+        wordBreaker.breakWord("abcde", corpus, 2, false);
         verify(mockTermsEnum, times(1)).seekExact(eq(new BytesRef("e")));
         verify(mockTermsEnum, times(1)).seekExact(eq(new BytesRef("de")));
         verify(mockTermsEnum, times(1)).seekExact(eq(new BytesRef("cde")));
@@ -304,7 +291,8 @@ public class WordBreakCompoundRewriterFactoryTest extends OpenSearchTestCase {
 
         when(mockTermsEnum.docFreq()).thenAnswer(invocation -> freqMap.get(currentTerm[0]));
 
-        wordBreaker.breakWord("abcde", indexReader, 2, true);
+        final LuceneTermCorpus corpus = new LuceneTermCorpus(() -> indexReader, "f2");
+        wordBreaker.breakWord("abcde", corpus, 2, false);
         verify(mockTermsEnum, times(1)).seekExact(eq(new BytesRef("e")));
         verify(mockTermsEnum, times(1)).seekExact(eq(new BytesRef("de")));
         verify(mockTermsEnum, times(1)).seekExact(eq(new BytesRef("cde")));
@@ -332,7 +320,7 @@ public class WordBreakCompoundRewriterFactoryTest extends OpenSearchTestCase {
         compoundConf.put("morphology", "GERMAN");
         final WordBreakCompoundRewriterFactory factory = new WordBreakCompoundRewriterFactory("r1");
         factory.configure(config);
-        final LuceneCompounder compounder = factory.getCompounder();
+        final MorphologicalCompounder compounder = factory.getCompounder();
         final MorphologicalWordBreaker wordBreaker = factory.getWordBreaker();
         assertNotNull(wordBreaker);
         final LeafReader indexReader = mock(LeafReader.class, withSettings().useConstructor());
@@ -349,8 +337,9 @@ public class WordBreakCompoundRewriterFactoryTest extends OpenSearchTestCase {
         when(indexReader.terms(eq("f2"))).thenReturn(mockTerms);
         when(mockTerms.iterator()).thenReturn(mockTermsEnum);
 
+        final LuceneTermCorpus corpus = new LuceneTermCorpus(() -> indexReader, "f2");
         compounder.combine(new querqy.model.Term[] {
-                new querqy.model.Term(null, "ab"), new querqy.model.Term(null, "de") }, indexReader, false);
+                new querqy.model.Term(null, "ab"), new querqy.model.Term(null, "de") }, corpus, false);
         // this will be generated by GERMAN morphology:
         verify(mockTermsEnum, times(1)).seekExact(eq(new BytesRef("absde")));
 


### PR DESCRIPTION
Closes #162
Supersedes #161 

## Summary

- Bump OpenSearch target from 3.5.0 to 3.6.0
- Bump querqy-lucene from 5.9.lucene1032.0 to 5.11.lucene1040.0 (targets Lucene 10.4.0)
- Bump querqy-core from 3.20.2 to 4.1.0
- Bump plugin version prefix from 1.2.os to 1.3.os
- Fix all import breakage from querqy-core 4.x package reorganisation (`querqy.rewrite.*` → `querqy.rewriter.*`)
- Rewrite `WordBreakCompoundRewriterFactory` to use querqy-core's `MorphologicalWordBreaker`/`MorphologicalCompounder` and querqy-lucene's `LuceneTermCorpus` (wordbreak classes were removed from querqy-lucene contrib and moved to querqy-core)
- Rename `META-INF/services` file for `QuerqyParserFactory` to reflect new package name

## Test plan

- [x] `./gradlew compileJava compileTestJava` passes
- [x] `./gradlew test` passes (151 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

