### PR TITLE
Expose optional compound modifier and compound.maxExpansions in WordBreak rewriter config

### DIFF
--- a/src/main/java/querqy/opensearch/rewriter/WordBreakCompoundRewriterFactory.java
+++ b/src/main/java/querqy/opensearch/rewriter/WordBreakCompoundRewriterFactory.java
@@ -30,10 +30,13 @@ import querqy.rewriter.wordbreak.MorphologicalCompounder;
 import querqy.rewriter.wordbreak.MorphologicalWordBreaker;
 import querqy.rewriter.wordbreak.Morphology;
 import querqy.rewriter.wordbreak.MorphologyProvider;
+import querqy.rewriter.wordbreak.OptionalModifierConfig;
+import querqy.rewriter.wordbreak.OptionalModifierPosition;
 import querqy.rewriter.wordbreak.WordBreakCompoundRewriter;
 import querqy.rewrite.SearchEngineRequestAdapter;
 import querqy.trie.TrieMap;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -46,13 +49,15 @@ public class WordBreakCompoundRewriterFactory extends OpenSearchRewriterFactory 
     static final int MAX_EVALUATIONS = 100;
 
     static final int DEFAULT_MIN_SUGGESTION_FREQ = 1;
-    static final int DEFAULT_MAX_COMBINE_LENGTH = 30;
     static final int DEFAULT_MIN_BREAK_LENGTH = 3;
     static final int DEFAULT_MAX_DECOMPOUND_EXPANSIONS = 3;
+    static final int DEFAULT_MAX_COMPOUND_EXPANSIONS = 3;
     static final boolean DEFAULT_LOWER_CASE_INPUT = false;
     static final boolean DEFAULT_ALWAYS_ADD_REVERSE_COMPOUNDS = false;
     static final boolean DEFAULT_VERIFY_DECOMPOUND_COLLATION = false;
     static final String DEFAULT_MORPHOLOGY_NAME = "DEFAULT";
+    static final String DEFAULT_OPTIONAL_MODIFIER_POSITION = OptionalModifierPosition.NONE.name();
+    static final float DEFAULT_OPTIONAL_MODIFIER_BOOST = 1.0f;
     private static final MorphologyProvider MORPHOLOGY_PROVIDER = new MorphologyProvider();
 
     private String dictionaryField;
@@ -63,8 +68,10 @@ public class WordBreakCompoundRewriterFactory extends OpenSearchRewriterFactory 
     private TrieMap<Boolean> reverseCompoundTriggerWords;
     private TrieMap<Boolean> protectedWords;
     private int maxDecompoundExpansions = DEFAULT_MAX_DECOMPOUND_EXPANSIONS;
+    private int maxCompoundExpansions = DEFAULT_MAX_COMPOUND_EXPANSIONS;
     private boolean verifyDecompoundCollation = DEFAULT_VERIFY_DECOMPOUND_COLLATION;
     private int minSuggestionFreq = DEFAULT_MIN_SUGGESTION_FREQ;
+    private OptionalModifierConfig optionalModifierConfig = OptionalModifierConfig.DISABLED;
 
     public WordBreakCompoundRewriterFactory(final String rewriterId) {
         super(rewriterId);
@@ -92,8 +99,10 @@ public class WordBreakCompoundRewriterFactory extends OpenSearchRewriterFactory 
         final String compoundMorphologyName = ConfigUtils.getStringArg(compoundConf, "morphology",
                 defaultMorphologyName);
         final Optional<Morphology> compoundMorphology = MORPHOLOGY_PROVIDER.get(compoundMorphologyName);
+        maxCompoundExpansions = ConfigUtils.getArg(compoundConf, "maxExpansions", DEFAULT_MAX_COMPOUND_EXPANSIONS);
         compounder = new MorphologicalCompounder(
-                compoundMorphology.orElse(MorphologyProvider.DEFAULT), lowerCaseInput, minSuggestionFreq);
+                compoundMorphology.orElse(MorphologyProvider.DEFAULT), lowerCaseInput, minSuggestionFreq,
+                maxCompoundExpansions);
 
         Map<String, Object> decompoundConf = (Map<String, Object>) config.get("decompound");
         if (decompoundConf == null) {
@@ -112,6 +121,22 @@ public class WordBreakCompoundRewriterFactory extends OpenSearchRewriterFactory 
                 DEFAULT_MAX_DECOMPOUND_EXPANSIONS);
         verifyDecompoundCollation = ConfigUtils.getArg(decompoundConf, "verifyCollation",
                 DEFAULT_VERIFY_DECOMPOUND_COLLATION);
+
+        final String optionalModifierPositionName = ConfigUtils.getStringArg(decompoundConf,
+                "optionalModifierPosition", DEFAULT_OPTIONAL_MODIFIER_POSITION);
+        final float optionalModifierBoost = ((Number) decompoundConf.getOrDefault(
+                "optionalModifierBoost", DEFAULT_OPTIONAL_MODIFIER_BOOST)).floatValue();
+        optionalModifierConfig = new OptionalModifierConfig(
+                parseOptionalModifierPosition(optionalModifierPositionName), optionalModifierBoost);
+    }
+
+    private static OptionalModifierPosition parseOptionalModifierPosition(final String name) {
+        try {
+            return OptionalModifierPosition.valueOf(name.trim().toUpperCase());
+        } catch (final IllegalArgumentException e) {
+            throw new IllegalArgumentException("No such optionalModifierPosition " + name + ". Valid values: "
+                    + Arrays.toString(OptionalModifierPosition.values()));
+        }
     }
 
     @Override
@@ -137,6 +162,17 @@ public class WordBreakCompoundRewriterFactory extends OpenSearchRewriterFactory 
                     errors.add("Unknown decompound morphology: " + morphologyName);
                 }
             });
+
+            final String optionalModifierPositionName = ConfigUtils.getStringArg(decompoundConf,
+                    "optionalModifierPosition", DEFAULT_OPTIONAL_MODIFIER_POSITION);
+            final float optionalModifierBoost = ((Number) decompoundConf.getOrDefault(
+                    "optionalModifierBoost", DEFAULT_OPTIONAL_MODIFIER_BOOST)).floatValue();
+            try {
+                new OptionalModifierConfig(
+                        parseOptionalModifierPosition(optionalModifierPositionName), optionalModifierBoost);
+            } catch (final IllegalArgumentException e) {
+                errors.add(e.getMessage());
+            }
         }
         final Map<String, Object> compoundConf = (Map<String, Object>) config.get("compound");
         if (compoundConf != null) {
@@ -165,7 +201,8 @@ public class WordBreakCompoundRewriterFactory extends OpenSearchRewriterFactory 
 
                 return new WordBreakCompoundRewriter(wordBreaker, compounder, corpus,
                         lowerCaseInput, alwaysAddReverseCompounds, reverseCompoundTriggerWords,
-                        maxDecompoundExpansions, verifyDecompoundCollation, protectedWords);
+                        maxDecompoundExpansions, verifyDecompoundCollation, protectedWords,
+                        optionalModifierConfig);
             }
 
             @Override
@@ -199,8 +236,16 @@ public class WordBreakCompoundRewriterFactory extends OpenSearchRewriterFactory 
         return maxDecompoundExpansions;
     }
 
+    public int getMaxCompoundExpansions() {
+        return maxCompoundExpansions;
+    }
+
     public boolean isVerifyDecompoundCollation() {
         return verifyDecompoundCollation;
+    }
+
+    public OptionalModifierConfig getOptionalModifierConfig() {
+        return optionalModifierConfig;
     }
 
     public MorphologicalCompounder getCompounder() {

--- a/src/test/java/querqy/opensearch/rewriter/WordBreakCompoundRewriterFactoryTest.java
+++ b/src/test/java/querqy/opensearch/rewriter/WordBreakCompoundRewriterFactoryTest.java
@@ -52,6 +52,8 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.index.TermsEnum;
 import querqy.rewriter.wordbreak.MorphologicalCompounder;
 import querqy.rewriter.wordbreak.MorphologicalWordBreaker;
+import querqy.rewriter.wordbreak.OptionalModifierConfig;
+import querqy.rewriter.wordbreak.OptionalModifierPosition;
 import querqy.rewriter.wordbreak.WordBreakCompoundRewriter;
 import querqy.rewrite.RewriterFactory;
 import querqy.trie.TrieMap;
@@ -106,6 +108,31 @@ public class WordBreakCompoundRewriterFactoryTest extends OpenSearchTestCase {
         assertThat(errors, Matchers.contains("Unknown morphology: IDIOLECT"));
     }
 
+    public void testValidateRefusesUnknownOptionalModifierPosition() {
+        final WordBreakCompoundRewriterFactory factory = new WordBreakCompoundRewriterFactory("r1");
+        final Map<String, Object> config = new HashMap<>();
+        config.put("dictionaryField", "f1");
+        final Map<String, Object> decompoundConf = new HashMap<>();
+        config.put("decompound", decompoundConf);
+        decompoundConf.put("optionalModifierPosition", "MIDDLE");
+
+        final List<String> errors = factory.validateConfiguration(config);
+        assertEquals(1, errors.size());
+        assertTrue(errors.getFirst().contains("MIDDLE"));
+    }
+
+    public void testValidateRefusesNonNeutralBoostWithoutOptionalModifierPosition() {
+        final WordBreakCompoundRewriterFactory factory = new WordBreakCompoundRewriterFactory("r1");
+        final Map<String, Object> config = new HashMap<>();
+        config.put("dictionaryField", "f1");
+        final Map<String, Object> decompoundConf = new HashMap<>();
+        config.put("decompound", decompoundConf);
+        decompoundConf.put("optionalModifierBoost", 1.5f);
+
+        final List<String> errors = factory.validateConfiguration(config);
+        assertEquals(1, errors.size());
+    }
+
     public void testThatDefaultConfigurationIsApplied() throws Exception {
 
         final WordBreakCompoundRewriterFactory factory = new WordBreakCompoundRewriterFactory("r1");
@@ -115,6 +142,9 @@ public class WordBreakCompoundRewriterFactoryTest extends OpenSearchTestCase {
         assertEquals(DEFAULT_ALWAYS_ADD_REVERSE_COMPOUNDS, factory.isAlwaysAddReverseCompounds());
         assertEquals(DEFAULT_VERIFY_DECOMPOUND_COLLATION, factory.isVerifyDecompoundCollation());
         assertEquals("f1", factory.getDictionaryField());
+        assertEquals(OptionalModifierConfig.DISABLED, factory.getOptionalModifierConfig());
+        assertEquals(WordBreakCompoundRewriterFactory.DEFAULT_MAX_COMPOUND_EXPANSIONS,
+                factory.getMaxCompoundExpansions());
 
         assertNotNull(factory.getCompounder());
 
@@ -167,7 +197,6 @@ public class WordBreakCompoundRewriterFactoryTest extends OpenSearchTestCase {
 
         final Map<String, Object> config = new HashMap<>();
         config.put("minSuggestionFreq", 11);
-        config.put("maxCombineLength", 22);
         config.put("minBreakLength", 1);
         config.put("dictionaryField", "f2");
         config.put("lowerCaseInput", !DEFAULT_LOWER_CASE_INPUT);
@@ -181,11 +210,15 @@ public class WordBreakCompoundRewriterFactoryTest extends OpenSearchTestCase {
 
         decompoundConf.put("verifyCollation", !DEFAULT_VERIFY_DECOMPOUND_COLLATION);
         decompoundConf.put("maxExpansions", 87);
+        decompoundConf.put("optionalModifierPosition", "first");
+        decompoundConf.put("optionalModifierBoost", 2.0f);
 
         final WordBreakCompoundRewriterFactory factory = new WordBreakCompoundRewriterFactory("r1");
         factory.configure(config);
 
         assertEquals(87, factory.getMaxDecompoundExpansions());
+        assertEquals(new OptionalModifierConfig(OptionalModifierPosition.FIRST, 2.0f),
+                factory.getOptionalModifierConfig());
 
         assertNotEquals(DEFAULT_LOWER_CASE_INPUT, factory.isLowerCaseInput());
         assertNotEquals(DEFAULT_ALWAYS_ADD_REVERSE_COMPOUNDS, factory.isAlwaysAddReverseCompounds());
@@ -247,7 +280,6 @@ public class WordBreakCompoundRewriterFactoryTest extends OpenSearchTestCase {
     public void testThatDecompoundMorphologyIsApplied() throws Exception {
         final Map<String, Object> config = new HashMap<>();
         config.put("minSuggestionFreq", 2);
-        config.put("maxCombineLength", 22);
         config.put("minBreakLength", 1);
         config.put("dictionaryField", "f2");
         config.put("lowerCaseInput", !DEFAULT_LOWER_CASE_INPUT);
@@ -304,7 +336,6 @@ public class WordBreakCompoundRewriterFactoryTest extends OpenSearchTestCase {
     public void testThatCompoundMorphologyIsApplied() throws Exception {
         final Map<String, Object> config = new HashMap<>();
         config.put("minSuggestionFreq", 11);
-        config.put("maxCombineLength", 5);
         config.put("minBreakLength", 1);
         config.put("dictionaryField", "f2");
         config.put("lowerCaseInput", !DEFAULT_LOWER_CASE_INPUT);
@@ -318,8 +349,10 @@ public class WordBreakCompoundRewriterFactoryTest extends OpenSearchTestCase {
         final Map<String, Object> compoundConf = new HashMap<>();
         config.put("compound", compoundConf);
         compoundConf.put("morphology", "GERMAN");
+        compoundConf.put("maxExpansions", 42);
         final WordBreakCompoundRewriterFactory factory = new WordBreakCompoundRewriterFactory("r1");
         factory.configure(config);
+        assertEquals(42, factory.getMaxCompoundExpansions());
         final MorphologicalCompounder compounder = factory.getCompounder();
         final MorphologicalWordBreaker wordBreaker = factory.getWordBreaker();
         assertNotNull(wordBreaker);


### PR DESCRIPTION
## Summary
- querqy-core 4.2.0 added `OptionalModifierPosition`/`OptionalModifierConfig` to the `WordBreakCompoundRewriter`, letting the first or last part of a decompounded token become a boosted SHOULD instead of a MUST (e.g. `gasgrill` → `gas +grill`). This wasn't reachable from the OpenSearch rewriter config; it now is, via `decompound.optionalModifierPosition` / `decompound.optionalModifierBoost`, with validation mirroring core's own parsing.
- Also exposes `compound.maxExpansions` (`MorphologicalCompounder`'s `maxCompoundExpansions`), mirroring the existing `decompound.maxExpansions`.
- Removes the dead `maxCombineLength` config key/constant, a leftover from the pre-`MorphologicalCompounder` (Lucene `WordBreakSpellChecker`) implementation that has been silently ignored since that migration.

## Test plan
- [x] `./gradlew test --tests "querqy.opensearch.rewriter.WordBreakCompoundRewriterFactoryTest"` — 13/13 pass, including new coverage for default/explicit optional-modifier config, invalid position/boost validation errors, and `compound.maxExpansions`.
- [x] `./gradlew test` — full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)