### PR TITLE
Read rewriter configurations, add revision, config_hash and saved_at (#167)

### DIFF
--- a/src/main/java/querqy/opensearch/QuerqyPlugin.java
+++ b/src/main/java/querqy/opensearch/QuerqyPlugin.java
@@ -51,12 +51,15 @@ import org.opensearch.watcher.ResourceWatcherService;
 import querqy.opensearch.infologging.Log4jSink;
 import querqy.opensearch.query.QuerqyQueryBuilder;
 import querqy.opensearch.rewriterstore.DeleteRewriterAction;
+import querqy.opensearch.rewriterstore.GetRewriterAction;
 import querqy.opensearch.rewriterstore.NodesClearRewriterCacheAction;
 import querqy.opensearch.rewriterstore.NodesReloadRewriterAction;
 import querqy.opensearch.rewriterstore.RestDeleteRewriterAction;
+import querqy.opensearch.rewriterstore.RestGetRewriterAction;
 import querqy.opensearch.rewriterstore.RestPutRewriterAction;
 import querqy.opensearch.rewriterstore.PutRewriterAction;
 import querqy.opensearch.rewriterstore.TransportDeleteRewriterAction;
+import querqy.opensearch.rewriterstore.TransportGetRewriterAction;
 import querqy.opensearch.rewriterstore.TransportNodesClearRewriterCacheAction;
 import querqy.opensearch.rewriterstore.TransportNodesReloadRewriterAction;
 import querqy.opensearch.rewriterstore.TransportPutRewriterAction;
@@ -105,7 +108,8 @@ public class QuerqyPlugin extends Plugin implements SearchPlugin, ActionPlugin {
                                              final IndexNameExpressionResolver indexNameExpressionResolver,
                                              final Supplier<DiscoveryNodes> nodesInCluster) {
 
-        return Arrays.asList(new RestPutRewriterAction(), new RestDeleteRewriterAction());
+        return Arrays.asList(new RestPutRewriterAction(), new RestDeleteRewriterAction(),
+                new RestGetRewriterAction());
 
     }
 
@@ -115,6 +119,7 @@ public class QuerqyPlugin extends Plugin implements SearchPlugin, ActionPlugin {
                 new ActionHandler<>(PutRewriterAction.INSTANCE, TransportPutRewriterAction.class),
                 new ActionHandler<>(NodesReloadRewriterAction.INSTANCE, TransportNodesReloadRewriterAction.class),
                 new ActionHandler<>(DeleteRewriterAction.INSTANCE, TransportDeleteRewriterAction.class),
+                new ActionHandler<>(GetRewriterAction.INSTANCE, TransportGetRewriterAction.class),
                 new ActionHandler<>(NodesClearRewriterCacheAction.INSTANCE, TransportNodesClearRewriterCacheAction
                         .class)
 

--- a/src/main/java/querqy/opensearch/rewriterstore/GetRewriterAction.java
+++ b/src/main/java/querqy/opensearch/rewriterstore/GetRewriterAction.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2026 Querqy for OpenSearch Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package querqy.opensearch.rewriterstore;
+
+import org.opensearch.action.ActionType;
+
+public class GetRewriterAction extends ActionType<GetRewriterResponse> {
+
+    public static final String NAME = "cluster:admin/querqy/rewriter/get";
+    public static final GetRewriterAction INSTANCE = new GetRewriterAction(NAME);
+
+    /**
+     * @param name The name of the action, must be unique across actions.
+     */
+    protected GetRewriterAction(final String name) {
+        super(name, GetRewriterResponse::new);
+    }
+
+}

--- a/src/main/java/querqy/opensearch/rewriterstore/GetRewriterRequest.java
+++ b/src/main/java/querqy/opensearch/rewriterstore/GetRewriterRequest.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2026 Querqy for OpenSearch Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package querqy.opensearch.rewriterstore;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+public class GetRewriterRequest extends ActionRequest {
+
+    private final String rewriterId;
+
+    public GetRewriterRequest(final StreamInput in) throws IOException {
+        super(in);
+        rewriterId = in.readOptionalString();
+    }
+
+    /**
+     * Request the configuration of all rewriters.
+     */
+    public GetRewriterRequest() {
+        this((String) null);
+    }
+
+    /**
+     * @param rewriterId The ID of the rewriter to read, or null to read all rewriters.
+     */
+    public GetRewriterRequest(final String rewriterId) {
+        super();
+        this.rewriterId = rewriterId;
+    }
+
+    @Override
+    public void writeTo(final StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeOptionalString(rewriterId);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    /**
+     * @return The ID of the rewriter to read, or null if all rewriters shall be listed.
+     */
+    public String getRewriterId() {
+        return rewriterId;
+    }
+
+}

--- a/src/main/java/querqy/opensearch/rewriterstore/GetRewriterResponse.java
+++ b/src/main/java/querqy/opensearch/rewriterstore/GetRewriterResponse.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2026 Querqy for OpenSearch Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package querqy.opensearch.rewriterstore;
+
+import org.opensearch.common.xcontent.StatusToXContentObject;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+public class GetRewriterResponse extends ActionResponse implements StatusToXContentObject {
+
+    public static final String FIELD_REWRITER = "rewriter";
+    public static final String FIELD_REWRITERS = "rewriters";
+
+    private final RewriterInfo rewriter;
+    private final List<RewriterInfo> rewriters;
+
+    /**
+     * The response to a request for a single rewriter.
+     *
+     * @param rewriter The rewriter information
+     */
+    public GetRewriterResponse(final RewriterInfo rewriter) {
+        this.rewriter = rewriter;
+        this.rewriters = null;
+    }
+
+    /**
+     * The response to a request for all rewriters.
+     *
+     * @param rewriters The rewriter information, one element per rewriter
+     */
+    public GetRewriterResponse(final List<RewriterInfo> rewriters) {
+        this.rewriter = null;
+        this.rewriters = rewriters;
+    }
+
+    public GetRewriterResponse(final StreamInput in) throws IOException {
+        super(in);
+        if (in.readBoolean()) {
+            rewriter = new RewriterInfo(in);
+            rewriters = null;
+        } else {
+            rewriter = null;
+            rewriters = in.readList(RewriterInfo::new);
+        }
+    }
+
+    @Override
+    public void writeTo(final StreamOutput out) throws IOException {
+        out.writeBoolean(rewriter != null);
+        if (rewriter != null) {
+            rewriter.writeTo(out);
+        } else {
+            out.writeList(rewriters);
+        }
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.OK;
+    }
+
+    @Override
+    public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
+
+        builder.startObject();
+
+        if (rewriter != null) {
+
+            builder.field(FIELD_REWRITER, rewriter);
+
+        } else {
+
+            builder.startArray(FIELD_REWRITERS);
+            for (final RewriterInfo rewriterInfo : rewriters) {
+                rewriterInfo.toXContent(builder, params);
+            }
+            builder.endArray();
+
+        }
+
+        builder.endObject();
+
+        return builder;
+    }
+
+    /**
+     * @return The requested rewriter, or null if this is the response to a request for all rewriters.
+     */
+    public RewriterInfo getRewriter() {
+        return rewriter;
+    }
+
+    /**
+     * @return All rewriters, or null if this is the response to a request for a single rewriter.
+     */
+    public List<RewriterInfo> getRewriters() {
+        return rewriters;
+    }
+
+}

--- a/src/main/java/querqy/opensearch/rewriterstore/PutRewriterRequest.java
+++ b/src/main/java/querqy/opensearch/rewriterstore/PutRewriterRequest.java
@@ -86,6 +86,18 @@ public class PutRewriterRequest extends ActionRequest {
             }
         }
 
+        final Object revision = content.get(RewriterConfigMapping.PROP_REVISION);
+        if (revision != null) {
+            if (!(revision instanceof String)) {
+                return ValidateActions.addValidationError("'" + RewriterConfigMapping.PROP_REVISION
+                        + "' must be a string but was: " + revision.getClass().getSimpleName(), null);
+            }
+            if (((String) revision).trim().isEmpty()) {
+                return ValidateActions.addValidationError("'" + RewriterConfigMapping.PROP_REVISION
+                        + "' must not be empty", null);
+            }
+        }
+
         final List<String> errors = AccessController.doPrivileged(
                 () -> {
 

--- a/src/main/java/querqy/opensearch/rewriterstore/RestGetRewriterAction.java
+++ b/src/main/java/querqy/opensearch/rewriterstore/RestGetRewriterAction.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2026 Querqy for OpenSearch Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package querqy.opensearch.rewriterstore;
+
+import static querqy.opensearch.rewriterstore.Constants.QUERQY_REWRITER_BASE_ROUTE;
+
+import org.opensearch.action.ActionRequestBuilder;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestStatusToXContentListener;
+import org.opensearch.transport.client.OpenSearchClient;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class RestGetRewriterAction extends BaseRestHandler {
+
+    public static final String PARAM_REWRITER_ID = "rewriterId";
+
+    @Override
+    public String getName() {
+        return "Read Querqy rewriter configurations";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return Arrays.asList(
+                new Route(RestRequest.Method.GET, QUERQY_REWRITER_BASE_ROUTE),
+                new Route(RestRequest.Method.GET, QUERQY_REWRITER_BASE_ROUTE + "/{rewriterId}"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) {
+
+        final GetRewriterRequestBuilder requestBuilder = createRequestBuilder(request, client);
+
+        return (channel) -> requestBuilder.execute(new RestStatusToXContentListener<>(channel));
+    }
+
+    GetRewriterRequestBuilder createRequestBuilder(final RestRequest request, final NodeClient client) {
+
+        final String rewriterIdParam = request.param(PARAM_REWRITER_ID);
+
+        // No rewriter ID: list all rewriters
+        final String rewriterId = (rewriterIdParam == null || rewriterIdParam.trim().isEmpty())
+                ? null
+                : rewriterIdParam.trim();
+
+        return new GetRewriterRequestBuilder(client, GetRewriterAction.INSTANCE, new GetRewriterRequest(rewriterId));
+    }
+
+
+    public static class GetRewriterRequestBuilder
+            extends ActionRequestBuilder<GetRewriterRequest, GetRewriterResponse> {
+
+        public GetRewriterRequestBuilder(final OpenSearchClient client, final GetRewriterAction action,
+                                        final GetRewriterRequest request) {
+            super(client, action, request);
+        }
+
+    }
+}

--- a/src/main/java/querqy/opensearch/rewriterstore/RewriterConfigMapping.java
+++ b/src/main/java/querqy/opensearch/rewriterstore/RewriterConfigMapping.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -58,6 +59,12 @@ public abstract class RewriterConfigMapping {
      * rewriter document - see {@link #computeConfigHash(String, Map)}.
      */
     public static final String PROP_CONFIG_HASH = "config_hash";
+
+    /**
+     * The point in time at which the rewriter configuration was saved, set by the node that received the
+     * configuration. Saved and returned as an ISO-8601 timestamp in UTC.
+     */
+    public static final String PROP_SAVED_AT = "saved_at";
 
     private static final String CONFIG_HASH_ALGORITHM = "SHA-256";
 
@@ -142,12 +149,24 @@ public abstract class RewriterConfigMapping {
 
     }
 
+    /**
+     * @param putRequestContent The payload of the request to save the rewriter
+     * @param savedAtMillis The point in time at which the rewriter is saved, in epoch millis, or null to save the
+     *                      rewriter without this information
+     * @return The document to save in the rewriter index
+     * @throws IOException if the rewriter config cannot be serialized
+     */
     @SuppressWarnings("unchecked")
-    public static Map<String, Object> toLuceneSource(final Map<String, Object> putRequestContent) throws IOException {
-        final Map<String, Object> source = new HashMap<>(putRequestContent.size() + 4);
+    public static Map<String, Object> toLuceneSource(final Map<String, Object> putRequestContent,
+                                                     final Long savedAtMillis) throws IOException {
+        final Map<String, Object> source = new HashMap<>(putRequestContent.size() + 5);
         source.put(PROP_TYPE, "rewriter");
         source.put(PROP_VERSION, CURRENT_MAPPING_VERSION);
         source.put(CURRENT.getRewriterClassNameProperty(), putRequestContent.get("class"));
+
+        if (savedAtMillis != null) {
+            source.put(PROP_SAVED_AT, toIsoInstant(savedAtMillis));
+        }
 
         final Map<String, Object> infoLoggingConfig = (Map<String, Object>) putRequestContent.get("info_logging");
         if (infoLoggingConfig != null) {
@@ -236,6 +255,29 @@ public abstract class RewriterConfigMapping {
     public String getRevision(final Map<String, Object> source) {
         final Object revision = source.get(PROP_REVISION);
         return revision == null ? null : revision.toString();
+    }
+
+    /**
+     * @param source The stored rewriter document
+     * @return The point in time at which the rewriter was saved, as an ISO-8601 timestamp in UTC, or null if the
+     * document doesn't carry this information - which is the case for rewriters that were saved before mapping
+     * version 4.
+     */
+    public String getSavedAt(final Map<String, Object> source) {
+
+        final Object savedAt = source.get(PROP_SAVED_AT);
+
+        if (savedAt == null) {
+            return null;
+        }
+
+        // We always save the timestamp as an ISO-8601 string but the date field type also accepts epoch millis,
+        // which is what we could see in a document that wasn't written by the rewriter API.
+        return (savedAt instanceof Number) ? toIsoInstant(((Number) savedAt).longValue()) : savedAt.toString();
+    }
+
+    private static String toIsoInstant(final long epochMillis) {
+        return Instant.ofEpochMilli(epochMillis).toString();
     }
 
     /**

--- a/src/main/java/querqy/opensearch/rewriterstore/RewriterConfigMapping.java
+++ b/src/main/java/querqy/opensearch/rewriterstore/RewriterConfigMapping.java
@@ -30,18 +30,36 @@ import org.opensearch.core.xcontent.XContentParser;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 public abstract class RewriterConfigMapping {
 
-    public static final int CURRENT_MAPPING_VERSION = 3;
+    public static final int CURRENT_MAPPING_VERSION = 4;
 
     public static final String PROP_VERSION = "version";
     public static final String PROP_TYPE = "type";
+
+    /**
+     * An optional, user-supplied identifier of the rewriter configuration revision. It is stored in the rewriter
+     * document as it was supplied and it is not interpreted in any way.
+     */
+    public static final String PROP_REVISION = "revision";
+
+    /**
+     * A hash of the rewriter configuration payload. This property is never stored but always derived from the stored
+     * rewriter document - see {@link #computeConfigHash(String, Map)}.
+     */
+    public static final String PROP_CONFIG_HASH = "config_hash";
+
+    private static final String CONFIG_HASH_ALGORITHM = "SHA-256";
 
     public static final RewriterConfigMapping CURRENT = new RewriterConfigMapping() {
 
@@ -51,24 +69,17 @@ public abstract class RewriterConfigMapping {
         }
 
         @Override
-        public final String getRewriterClassNameProperty() {
-            return "class";
+        public boolean isConfigStoredCanonically() {
+            return true;
         }
 
-        @Override
-        public String getInfoLoggingProperty() {
-            return "info_logging";
-        }
+    };
+
+    public static final RewriterConfigMapping V3_MAPPING = new RewriterConfigMapping() {
 
         @Override
-        public String getRewriterClassName(final String rewriterId, final Map<String, Object> source) {
-            return (String) source.get(getRewriterClassNameProperty());
-        }
-
-        @Override
-        @SuppressWarnings("unchecked")
-        public Map<String, Object> getInfoLoggingConfig(final String rewriterId, final Map<String, Object> source) {
-            return (Map<String, Object>) source.get(getInfoLoggingProperty());
+        public String getConfigStringProperty() {
+            return "config_v_003";
         }
 
     };
@@ -80,39 +91,35 @@ public abstract class RewriterConfigMapping {
             return "config";
         }
 
-        @Override
-        public final String getRewriterClassNameProperty() {
-            return "class";
-        }
-
-        @Override
-        public String getInfoLoggingProperty() {
-            return "info_logging";
-        }
-
-        @Override
-        public String getRewriterClassName(final String rewriterId, final Map<String, Object> source) {
-            return (String) source.get(getRewriterClassNameProperty());
-        }
-
-        @Override
-        @SuppressWarnings("unchecked")
-        public Map<String, Object> getInfoLoggingConfig(final String rewriterId, final Map<String, Object> source) {
-            return (Map<String, Object>) source.get(getInfoLoggingProperty());
-        }
-
     };
 
 
-
-
-
-    public abstract String getRewriterClassNameProperty();
     public abstract String getConfigStringProperty();
-    public abstract String getInfoLoggingProperty();
-    public abstract String getRewriterClassName(final String rewriterId, final Map<String, Object> source);
-    public abstract Map<String, Object> getInfoLoggingConfig(final String rewriterId, final Map<String, Object> source);
 
+    public String getRewriterClassNameProperty() {
+        return "class";
+    }
+
+    public String getInfoLoggingProperty() {
+        return "info_logging";
+    }
+
+    public String getRewriterClassName(final String rewriterId, final Map<String, Object> source) {
+        return (String) source.get(getRewriterClassNameProperty());
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> getInfoLoggingConfig(final String rewriterId, final Map<String, Object> source) {
+        return (Map<String, Object>) source.get(getInfoLoggingProperty());
+    }
+
+    /**
+     * @return true iff this mapping stores the rewriter config in canonical form, which allows us to derive the config
+     * hash from the stored value without parsing it again.
+     */
+    public boolean isConfigStoredCanonically() {
+        return false;
+    }
 
 
     public static RewriterConfigMapping getMapping(final Map<String, Object> source) {
@@ -121,6 +128,10 @@ public abstract class RewriterConfigMapping {
 
         if (version == null) {
             return PRE3_MAPPING;
+        }
+
+        if (version == 3) {
+            return V3_MAPPING;
         }
 
         if (version == CURRENT_MAPPING_VERSION) {
@@ -133,7 +144,7 @@ public abstract class RewriterConfigMapping {
 
     @SuppressWarnings("unchecked")
     public static Map<String, Object> toLuceneSource(final Map<String, Object> putRequestContent) throws IOException {
-        final Map<String, Object> source = new HashMap<>(putRequestContent.size() + 3);
+        final Map<String, Object> source = new HashMap<>(putRequestContent.size() + 4);
         source.put(PROP_TYPE, "rewriter");
         source.put(PROP_VERSION, CURRENT_MAPPING_VERSION);
         source.put(CURRENT.getRewriterClassNameProperty(), putRequestContent.get("class"));
@@ -143,9 +154,16 @@ public abstract class RewriterConfigMapping {
             source.put(CURRENT.getInfoLoggingProperty(), infoLoggingConfig);
         }
 
+        final Object revision = putRequestContent.get(PROP_REVISION);
+        if (revision != null) {
+            source.put(PROP_REVISION, revision.toString());
+        }
+
         final Map<String, Object> config = (Map<String, Object>) putRequestContent.get("config");
         if (config != null) {
-            final String jsonString = mapToJsonString(config);
+            // We store the config in canonical form so that the config hash can be derived from the stored value
+            // without parsing it again and so that it doesn't depend on map iteration order.
+            final String jsonString = toCanonicalJsonString(config);
             // See constraints in org.elasticsearch.index.mapper.KeywordFieldMapper.indexValue()
             source.put(CURRENT.getConfigStringProperty(), stringToSourceValue(jsonString, 32766));
         }
@@ -190,51 +208,176 @@ public abstract class RewriterConfigMapping {
 
     public Map<String, Object> getConfig(final String rewriterId, final Map<String, Object> source) {
 
+        final String configStr = getConfigString(source);
+
+        if (configStr == null) {
+            return Collections.emptyMap();
+        }
+
+        final XContentParser parser;
+        try {
+            parser = XContentHelper.createParser(null, null, new BytesArray(configStr), XContentType.JSON);
+        } catch (final IOException e) {
+            throw new OpenSearchException(e);
+        }
+        try {
+            return parser.map();
+        } catch (final IOException e) {
+            throw new ParsingException(parser.getTokenLocation(), "Could not load 'config' of rewriter " + rewriterId);
+        }
+
+    }
+
+    /**
+     * @param source The stored rewriter document
+     * @return The revision that was supplied by the user when the rewriter was saved, or null if the user didn't
+     * supply any revision information.
+     */
+    public String getRevision(final Map<String, Object> source) {
+        final Object revision = source.get(PROP_REVISION);
+        return revision == null ? null : revision.toString();
+    }
+
+    /**
+     * <p>Computes a hash over the configuration payload of a stored rewriter: the rewriter class, the rewriter config
+     * and the info logging config. {@link #PROP_REVISION} is not part of the hash.</p>
+     *
+     * <p>The hash is never stored but always derived from the stored document. This keeps it from becoming stale if a
+     * rewriter document is written without using the rewriter API - by bulk indexing, reindexing or restoring a
+     * snapshot, for example.</p>
+     *
+     * @param rewriterId The rewriter ID (used in error messages only)
+     * @param source The stored rewriter document
+     * @return The hash, as a lower-case hex string
+     */
+    public String computeConfigHash(final String rewriterId, final Map<String, Object> source) {
+
+        final StringBuilder hashInput = new StringBuilder(256);
+
+        try {
+
+            hashInput.append("{\"class\":").append(toCanonicalJsonString(getRewriterClassName(rewriterId, source)));
+
+            final String configString = getConfigString(source);
+            if (configString != null) {
+                hashInput.append(",\"config\":").append(isConfigStoredCanonically()
+                        ? configString
+                        : toCanonicalJsonString(getConfig(rewriterId, source)));
+            }
+
+            final Map<String, Object> infoLoggingConfig = getInfoLoggingConfig(rewriterId, source);
+            if (infoLoggingConfig != null) {
+                hashInput.append(",\"info_logging\":").append(toCanonicalJsonString(infoLoggingConfig));
+            }
+
+            hashInput.append('}');
+
+        } catch (final IOException e) {
+            throw new OpenSearchException("Could not compute the config hash of rewriter " + rewriterId, e);
+        }
+
+        return hash(hashInput.toString());
+    }
+
+    /**
+     * @param source The stored rewriter document
+     * @return The stored config as a JSON string, joining the parts of a config that had to be split up on saving, or
+     * null if this document doesn't have a config.
+     */
+    @SuppressWarnings("unchecked")
+    protected String getConfigString(final Map<String, Object> source) {
+
         final Object configStringValue = source.get(getConfigStringProperty());
+
         final String configStr;
         if (configStringValue == null) {
             configStr = null;
         } else if (configStringValue instanceof String) {
             configStr = ((String) configStringValue).trim();
-        } else if (configStringValue instanceof List || configStringValue.getClass().isArray()) {
+        } else if (configStringValue instanceof List) {
+            // this is what we get for a config that had to be split up when we read the document from the index
             configStr = String.join("", (Iterable<? extends CharSequence>) configStringValue).trim();
+        } else if (configStringValue instanceof String[]) {
+            // ... and this is what stringToSourceValue produces for such a config
+            configStr = String.join("", (String[]) configStringValue).trim();
         } else {
             throw new IllegalArgumentException("Unexpected config value class: " + configStringValue);
         }
 
-        final Map<String, Object> config;
-
-        if (configStr != null && configStr.length() > 0) {
-
-            final XContentParser parser;
-            try {
-                parser = XContentHelper.createParser(null, null, new BytesArray(configStr),
-                        XContentType.JSON);
-            } catch (final IOException e) {
-                throw new OpenSearchException(e);
-            }
-            try {
-                config = parser.map();
-            } catch (final IOException e) {
-                throw new ParsingException(parser.getTokenLocation(), "Could not load 'config' of rewriter "
-                        + rewriterId);
-            }
-
-        } else {
-            config = Collections.emptyMap();
-        }
-
-        return config;
+        return (configStr == null || configStr.isEmpty()) ? null : configStr;
     }
 
-    private static String mapToJsonString(final Map<String, Object> map) throws IOException {
+    /**
+     * Renders a value as a JSON string, sorting the properties of all (nested) objects by property name so that the
+     * output depends on the value alone and not on map iteration order.
+     *
+     * @param value The value to render
+     * @return The JSON representation of the value
+     * @throws IOException if the value cannot be rendered
+     */
+    static String toCanonicalJsonString(final Object value) throws IOException {
         try (final ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
             final XContentBuilder builder = new XContentBuilder(XContentType.JSON.xContent(), bos);
-            builder.value(map);
+            builder.value(canonicalize(value));
             builder.flush();
             builder.close();
             return new String(bos.toByteArray(), StandardCharsets.UTF_8);
         }
+    }
+
+    private static Object canonicalize(final Object value) {
+
+        if (value instanceof Map) {
+
+            final Map<String, Object> canonicalized = new TreeMap<>();
+            for (final Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+                canonicalized.put(String.valueOf(entry.getKey()), canonicalize(entry.getValue()));
+            }
+            return canonicalized;
+
+        }
+
+        if (value instanceof Collection) {
+
+            final Collection<?> collection = (Collection<?>) value;
+            final List<Object> canonicalized = new ArrayList<>(collection.size());
+            for (final Object element : collection) {
+                canonicalized.add(canonicalize(element));
+            }
+            return canonicalized;
+
+        }
+
+        if (value instanceof Object[]) {
+
+            final Object[] array = (Object[]) value;
+            final List<Object> canonicalized = new ArrayList<>(array.length);
+            for (final Object element : array) {
+                canonicalized.add(canonicalize(element));
+            }
+            return canonicalized;
+
+        }
+
+        return value;
+    }
+
+    private static String hash(final String input) {
+
+        final MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance(CONFIG_HASH_ALGORITHM);
+        } catch (final NoSuchAlgorithmException e) {
+            throw new IllegalStateException(CONFIG_HASH_ALGORITHM + " is not available", e);
+        }
+
+        final byte[] bytes = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+
+        final StringBuilder hex = new StringBuilder(bytes.length * 2);
+        for (final byte b : bytes) {
+            hex.append(Character.forDigit((b >> 4) & 0xf, 16)).append(Character.forDigit(b & 0xf, 16));
+        }
+        return hex.toString();
     }
 
 }

--- a/src/main/java/querqy/opensearch/rewriterstore/RewriterInfo.java
+++ b/src/main/java/querqy/opensearch/rewriterstore/RewriterInfo.java
@@ -40,6 +40,7 @@ public class RewriterInfo implements Writeable, ToXContentObject {
     private final String rewriterClassName;
     private final String revision;
     private final String configHash;
+    private final String savedAt;
     private final Map<String, Object> config;
     private final Map<String, Object> infoLoggingConfig;
 
@@ -61,17 +62,19 @@ public class RewriterInfo implements Writeable, ToXContentObject {
                 mapping.getRewriterClassName(rewriterId, source),
                 mapping.getRevision(source),
                 mapping.computeConfigHash(rewriterId, source),
+                mapping.getSavedAt(source),
                 includeConfig ? mapping.getConfig(rewriterId, source) : null,
                 mapping.getInfoLoggingConfig(rewriterId, source));
     }
 
     public RewriterInfo(final String rewriterId, final String rewriterClassName, final String revision,
-                        final String configHash, final Map<String, Object> config,
+                        final String configHash, final String savedAt, final Map<String, Object> config,
                         final Map<String, Object> infoLoggingConfig) {
         this.rewriterId = rewriterId;
         this.rewriterClassName = rewriterClassName;
         this.revision = revision;
         this.configHash = configHash;
+        this.savedAt = savedAt;
         this.config = config;
         this.infoLoggingConfig = infoLoggingConfig;
     }
@@ -81,6 +84,7 @@ public class RewriterInfo implements Writeable, ToXContentObject {
         rewriterClassName = in.readOptionalString();
         revision = in.readOptionalString();
         configHash = in.readString();
+        savedAt = in.readOptionalString();
         config = in.readBoolean() ? in.readMap() : null;
         infoLoggingConfig = in.readBoolean() ? in.readMap() : null;
     }
@@ -91,6 +95,7 @@ public class RewriterInfo implements Writeable, ToXContentObject {
         out.writeOptionalString(rewriterClassName);
         out.writeOptionalString(revision);
         out.writeString(configHash);
+        out.writeOptionalString(savedAt);
         out.writeBoolean(config != null);
         if (config != null) {
             out.writeMap(config);
@@ -114,6 +119,10 @@ public class RewriterInfo implements Writeable, ToXContentObject {
         }
 
         builder.field(RewriterConfigMapping.PROP_CONFIG_HASH, configHash);
+
+        if (savedAt != null) {
+            builder.field(RewriterConfigMapping.PROP_SAVED_AT, savedAt);
+        }
 
         if (infoLoggingConfig != null) {
             builder.field(RewriterConfigMapping.CURRENT.getInfoLoggingProperty(), infoLoggingConfig);
@@ -146,6 +155,14 @@ public class RewriterInfo implements Writeable, ToXContentObject {
 
     public String getConfigHash() {
         return configHash;
+    }
+
+    /**
+     * @return The point in time at which the rewriter was saved, as an ISO-8601 timestamp in UTC, or null for a
+     * rewriter that was saved before this information was recorded.
+     */
+    public String getSavedAt() {
+        return savedAt;
     }
 
     /**

--- a/src/main/java/querqy/opensearch/rewriterstore/RewriterInfo.java
+++ b/src/main/java/querqy/opensearch/rewriterstore/RewriterInfo.java
@@ -1,0 +1,162 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2026 Querqy for OpenSearch Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package querqy.opensearch.rewriterstore;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * The information about a stored rewriter that is returned by {@link GetRewriterAction}. Its properties are named
+ * like the properties of the payload of a {@link PutRewriterRequest} so that the output can be fed back into a PUT
+ * request, for example to copy a rewriter from one cluster to another.
+ */
+public class RewriterInfo implements Writeable, ToXContentObject {
+
+    public static final String FIELD_REWRITER_ID = "rewriter_id";
+
+    private final String rewriterId;
+    private final String rewriterClassName;
+    private final String revision;
+    private final String configHash;
+    private final Map<String, Object> config;
+    private final Map<String, Object> infoLoggingConfig;
+
+    /**
+     * Reads the rewriter information from a stored rewriter document.
+     *
+     * @param rewriterId The ID of the rewriter
+     * @param source The stored rewriter document
+     * @param includeConfig Include the rewriter config in the information? Configs can be very large, which is why
+     *                      they are not included when rewriters are listed.
+     * @return The rewriter information
+     */
+    public static RewriterInfo fromSource(final String rewriterId, final Map<String, Object> source,
+                                          final boolean includeConfig) {
+
+        final RewriterConfigMapping mapping = RewriterConfigMapping.getMapping(source);
+
+        return new RewriterInfo(rewriterId,
+                mapping.getRewriterClassName(rewriterId, source),
+                mapping.getRevision(source),
+                mapping.computeConfigHash(rewriterId, source),
+                includeConfig ? mapping.getConfig(rewriterId, source) : null,
+                mapping.getInfoLoggingConfig(rewriterId, source));
+    }
+
+    public RewriterInfo(final String rewriterId, final String rewriterClassName, final String revision,
+                        final String configHash, final Map<String, Object> config,
+                        final Map<String, Object> infoLoggingConfig) {
+        this.rewriterId = rewriterId;
+        this.rewriterClassName = rewriterClassName;
+        this.revision = revision;
+        this.configHash = configHash;
+        this.config = config;
+        this.infoLoggingConfig = infoLoggingConfig;
+    }
+
+    public RewriterInfo(final StreamInput in) throws IOException {
+        rewriterId = in.readString();
+        rewriterClassName = in.readOptionalString();
+        revision = in.readOptionalString();
+        configHash = in.readString();
+        config = in.readBoolean() ? in.readMap() : null;
+        infoLoggingConfig = in.readBoolean() ? in.readMap() : null;
+    }
+
+    @Override
+    public void writeTo(final StreamOutput out) throws IOException {
+        out.writeString(rewriterId);
+        out.writeOptionalString(rewriterClassName);
+        out.writeOptionalString(revision);
+        out.writeString(configHash);
+        out.writeBoolean(config != null);
+        if (config != null) {
+            out.writeMap(config);
+        }
+        out.writeBoolean(infoLoggingConfig != null);
+        if (infoLoggingConfig != null) {
+            out.writeMap(infoLoggingConfig);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
+
+        builder.startObject();
+
+        builder.field(FIELD_REWRITER_ID, rewriterId);
+        builder.field(RewriterConfigMapping.CURRENT.getRewriterClassNameProperty(), rewriterClassName);
+
+        if (revision != null) {
+            builder.field(RewriterConfigMapping.PROP_REVISION, revision);
+        }
+
+        builder.field(RewriterConfigMapping.PROP_CONFIG_HASH, configHash);
+
+        if (infoLoggingConfig != null) {
+            builder.field(RewriterConfigMapping.CURRENT.getInfoLoggingProperty(), infoLoggingConfig);
+        }
+
+        if (config != null) {
+            builder.field("config", config);
+        }
+
+        builder.endObject();
+
+        return builder;
+    }
+
+    public String getRewriterId() {
+        return rewriterId;
+    }
+
+    public String getRewriterClassName() {
+        return rewriterClassName;
+    }
+
+    /**
+     * @return The revision that was supplied by the user when the rewriter was saved, or null if the user didn't
+     * supply any revision information.
+     */
+    public String getRevision() {
+        return revision;
+    }
+
+    public String getConfigHash() {
+        return configHash;
+    }
+
+    /**
+     * @return The rewriter config, or null if this information was requested without the config.
+     */
+    public Map<String, Object> getConfig() {
+        return config;
+    }
+
+    public Map<String, Object> getInfoLoggingConfig() {
+        return infoLoggingConfig;
+    }
+
+}

--- a/src/main/java/querqy/opensearch/rewriterstore/TransportGetRewriterAction.java
+++ b/src/main/java/querqy/opensearch/rewriterstore/TransportGetRewriterAction.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2026 Querqy for OpenSearch Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package querqy.opensearch.rewriterstore;
+
+import static querqy.opensearch.rewriterstore.Constants.QUERQY_INDEX_NAME;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ResourceNotFoundException;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.SearchHit;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+public class TransportGetRewriterAction extends HandledTransportAction<GetRewriterRequest, GetRewriterResponse> {
+
+    private static final Logger LOGGER = LogManager.getLogger(TransportGetRewriterAction.class);
+
+    /**
+     * The maximum number of rewriters that will be returned when rewriters are listed. This is the default value of
+     * the index.max_result_window setting, which a search request cannot exceed anyway.
+     */
+    static final int MAX_LISTED_REWRITERS = 10000;
+
+    private final Client client;
+
+    @Inject
+    public TransportGetRewriterAction(final TransportService transportService, final ActionFilters actionFilters,
+                                      final Client client) {
+        super(GetRewriterAction.NAME, false, transportService, actionFilters, GetRewriterRequest::new);
+        this.client = client;
+    }
+
+    @Override
+    protected void doExecute(final Task task, final GetRewriterRequest request,
+                             final ActionListener<GetRewriterResponse> listener) {
+
+        final String rewriterId = request.getRewriterId();
+
+        if (rewriterId == null) {
+            listRewriters(listener);
+        } else {
+            getRewriter(rewriterId, listener);
+        }
+
+    }
+
+    protected void getRewriter(final String rewriterId, final ActionListener<GetRewriterResponse> listener) {
+
+        client.prepareGet(QUERQY_INDEX_NAME, rewriterId).execute(new ActionListener<GetResponse>() {
+
+            @Override
+            public void onResponse(final GetResponse getResponse) {
+
+                final Map<String, Object> source = getResponse.getSource();
+
+                if (source == null || !"rewriter".equals(source.get(RewriterConfigMapping.PROP_TYPE))) {
+                    listener.onFailure(rewriterNotFound(rewriterId));
+                    return;
+                }
+
+                try {
+                    listener.onResponse(new GetRewriterResponse(RewriterInfo.fromSource(rewriterId, source, true)));
+                } catch (final Exception e) {
+                    listener.onFailure(e);
+                }
+
+            }
+
+            @Override
+            public void onFailure(final Exception e) {
+                if (isIndexNotFound(e)) {
+                    listener.onFailure(rewriterNotFound(rewriterId));
+                } else {
+                    listener.onFailure(e);
+                }
+            }
+        });
+
+    }
+
+    protected void listRewriters(final ActionListener<GetRewriterResponse> listener) {
+
+        client.prepareSearch(QUERQY_INDEX_NAME)
+                // Don't fail if the rewriter index hasn't been created yet
+                .setIndicesOptions(IndicesOptions.lenientExpandOpen())
+                .setQuery(QueryBuilders.termQuery(RewriterConfigMapping.PROP_TYPE, "rewriter"))
+                .setSize(MAX_LISTED_REWRITERS)
+                .execute(new ActionListener<SearchResponse>() {
+
+                    @Override
+                    public void onResponse(final SearchResponse searchResponse) {
+
+                        try {
+
+                            final SearchHit[] hits = searchResponse.getHits().getHits();
+
+                            if (hits.length == MAX_LISTED_REWRITERS) {
+                                LOGGER.warn("Listing not more than {} rewriters", MAX_LISTED_REWRITERS);
+                            }
+
+                            final List<RewriterInfo> rewriters = new ArrayList<>(hits.length);
+                            for (final SearchHit hit : hits) {
+                                // Configs can be very large - we only return them for a single rewriter
+                                rewriters.add(RewriterInfo.fromSource(hit.getId(), hit.getSourceAsMap(), false));
+                            }
+                            rewriters.sort(Comparator.comparing(RewriterInfo::getRewriterId));
+
+                            listener.onResponse(new GetRewriterResponse(rewriters));
+
+                        } catch (final Exception e) {
+                            listener.onFailure(e);
+                        }
+
+                    }
+
+                    @Override
+                    public void onFailure(final Exception e) {
+                        if (isIndexNotFound(e)) {
+                            listener.onResponse(new GetRewriterResponse(Collections.emptyList()));
+                        } else {
+                            listener.onFailure(e);
+                        }
+                    }
+                });
+
+    }
+
+    private static ResourceNotFoundException rewriterNotFound(final String rewriterId) {
+        return new ResourceNotFoundException("Rewriter not found: " + rewriterId);
+    }
+
+    private static boolean isIndexNotFound(final Exception e) {
+        return (e instanceof IndexNotFoundException) || (e.getCause() instanceof IndexNotFoundException);
+    }
+
+}

--- a/src/main/java/querqy/opensearch/rewriterstore/TransportPutRewriterAction.java
+++ b/src/main/java/querqy/opensearch/rewriterstore/TransportPutRewriterAction.java
@@ -42,6 +42,7 @@ import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.service.ClusterService;
 
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
@@ -92,25 +93,14 @@ public class TransportPutRewriterAction extends HandledTransportAction<PutRewrit
 
                     final Map<String, Object> properties = (Map<String, Object>) mappings.get(QUERQY_INDEX_NAME)
                             .getSourceAsMap().get("properties");
-                    if (!properties.containsKey("info_logging")) {
-                        try {
-                            update1To3(indicesClient);
-                            mappingsVersionChecked = true;
-                        } catch (final Exception e) {
-                            listener.onFailure(e);
-                            return;
-                        }
-
-                    } else if (!properties.containsKey(RewriterConfigMapping.CURRENT.getConfigStringProperty())) {
-                        try {
-                            update2To3(indicesClient);
-                            mappingsVersionChecked = true;
-                        } catch (final Exception e) {
-                            listener.onFailure(e);
-                            return;
-                        }
-
+                    try {
+                        updateMappings(indicesClient, properties);
+                        mappingsVersionChecked = true;
+                    } catch (final Exception e) {
+                        listener.onFailure(e);
+                        return;
                     }
+
                 }
                 try {
                     saveRewriter(task, request, listener);
@@ -152,54 +142,64 @@ public class TransportPutRewriterAction extends HandledTransportAction<PutRewrit
 
     }
 
-    protected void update1To3(final IndicesAdminClient indicesClient ) throws ExecutionException,
-            InterruptedException {
+    /**
+     * <p>Adds the properties that are missing in the mappings of the rewriter index, migrating the mappings of any
+     * earlier mapping version to {@link RewriterConfigMapping#CURRENT_MAPPING_VERSION}.</p>
+     *
+     * @param indicesClient The client for index operations
+     * @param existingProperties The properties that are currently mapped in the rewriter index
+     * @throws ExecutionException if updating the mappings fails
+     * @throws InterruptedException if updating the mappings is interrupted
+     */
+    protected void updateMappings(final IndicesAdminClient indicesClient, final Map<String, Object> existingProperties)
+            throws ExecutionException, InterruptedException {
+
+        final RewriterConfigMapping mapping = RewriterConfigMapping.CURRENT;
+
+        // property name -> mapping definition of that property
+        final Map<String, String> missingProperties = new LinkedHashMap<>();
+
+        if (!existingProperties.containsKey(mapping.getInfoLoggingProperty())) {
+            missingProperties.put(mapping.getInfoLoggingProperty(),
+                    "      \"" + mapping.getInfoLoggingProperty() + "\": {\n" +
+                    "        \"properties\": {\n" +
+                    "          \"sinks\": {\"type\" : \"keyword\" }\n" +
+                    "        }\n" +
+                    "      }");
+        }
+
+        if (!existingProperties.containsKey(mapping.getConfigStringProperty())) {
+            missingProperties.put(mapping.getConfigStringProperty(),
+                    "      \"" + mapping.getConfigStringProperty() + "\": {\n" +
+                    "        \"type\" : \"keyword\",\n" +
+                    "        \"doc_values\": false,\n" +
+                    "        \"index\": false\n" +
+                    "      }");
+        }
+
+        if (!existingProperties.containsKey(RewriterConfigMapping.PROP_REVISION)) {
+            missingProperties.put(RewriterConfigMapping.PROP_REVISION,
+                    "      \"" + RewriterConfigMapping.PROP_REVISION + "\": {\"type\" : \"keyword\" }");
+        }
+
+        if (missingProperties.isEmpty()) {
+            return;
+        }
+
         final PutMappingRequest request = new PutMappingRequest(QUERQY_INDEX_NAME).source(
                 "{\n" +
                         "    \"properties\": {\n" +
-                        "      \"info_logging\": {\n" +
-                        "        \"properties\": {\n" +
-                        "          \"sinks\": {\"type\" : \"keyword\" }\n" +
-                        "        }\n" +
-                        "      },\n" +
-                        "      \"config_v_003\": {\n" +
-                        "        \"type\" : \"keyword\",\n" +
-                        "        \"doc_values\": false,\n" +
-                        "        \"index\": false\n" +
-                        "      }" +
+                        String.join(",\n", missingProperties.values()) + "\n" +
                         "    }\n" +
                         "}", XContentType.JSON
         );
 
         if (!indicesClient.putMapping(request).get().isAcknowledged()) {
-            throw new IllegalStateException("Adding info_logging to mappings not " +
-                    "acknowledged");
+            throw new IllegalStateException("Adding properties " + missingProperties.keySet()
+                    + " to mappings not acknowledged");
         }
 
-        LOGGER.info("Added info_logging property and config_v_003 to index {}", QUERQY_INDEX_NAME);
-
-    }
-
-    protected void update2To3(final IndicesAdminClient indicesClient ) throws ExecutionException,
-            InterruptedException {
-        final PutMappingRequest request = new PutMappingRequest(QUERQY_INDEX_NAME).source(
-                "{\n" +
-                        "    \"properties\": {\n" +
-                        "      \"config_v_003\": {\n" +
-                        "        \"type\" : \"keyword\",\n" +
-                        "        \"doc_values\": false,\n" +
-                        "        \"index\": false\n" +
-                        "      }" +
-                        "    }\n" +
-                        "}", XContentType.JSON
-        );
-
-        if (!indicesClient.putMapping(request).get().isAcknowledged()) {
-            throw new IllegalStateException("Adding config_v_003 to mappings not " +
-                    "acknowledged");
-        }
-
-        LOGGER.info("Added config_v_003 property to index {}", QUERQY_INDEX_NAME);
+        LOGGER.info("Added properties {} to index {}", missingProperties.keySet(), QUERQY_INDEX_NAME);
 
     }
 

--- a/src/main/java/querqy/opensearch/rewriterstore/TransportPutRewriterAction.java
+++ b/src/main/java/querqy/opensearch/rewriterstore/TransportPutRewriterAction.java
@@ -49,6 +49,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.tasks.Task;
+import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
 import org.opensearch.transport.client.IndicesAdminClient;
@@ -63,15 +64,18 @@ public class TransportPutRewriterAction extends HandledTransportAction<PutRewrit
 
     private final Client client;
     private final ClusterService clusterService;
+    private final ThreadPool threadPool;
     private final Settings settings;
     private boolean mappingsVersionChecked = false;
 
     @Inject
     public TransportPutRewriterAction(final TransportService transportService, final ActionFilters actionFilters,
-                                      final ClusterService clusterService, final Client client, final Settings settings)
+                                      final ClusterService clusterService, final ThreadPool threadPool,
+                                      final Client client, final Settings settings)
     {
         super(NAME, false, transportService, actionFilters, PutRewriterRequest::new);
         this.clusterService = clusterService;
+        this.threadPool = threadPool;
         this.client = client;
         this.settings = settings;
     }
@@ -182,6 +186,11 @@ public class TransportPutRewriterAction extends HandledTransportAction<PutRewrit
                     "      \"" + RewriterConfigMapping.PROP_REVISION + "\": {\"type\" : \"keyword\" }");
         }
 
+        if (!existingProperties.containsKey(RewriterConfigMapping.PROP_SAVED_AT)) {
+            missingProperties.put(RewriterConfigMapping.PROP_SAVED_AT,
+                    "      \"" + RewriterConfigMapping.PROP_SAVED_AT + "\": {\"type\" : \"date\" }");
+        }
+
         if (missingProperties.isEmpty()) {
             return;
         }
@@ -243,7 +252,9 @@ public class TransportPutRewriterAction extends HandledTransportAction<PutRewrit
     private IndexRequest buildIndexRequest(final Task parentTask, final PutRewriterRequest request) throws IOException {
 
         final IndexRequest indexRequest = client.prepareIndex(QUERQY_INDEX_NAME).setId(request.getRewriterId())
-                .setCreate(false).setSource(RewriterConfigMapping.toLuceneSource(request.getContent()))
+                .setCreate(false)
+                .setSource(RewriterConfigMapping.toLuceneSource(request.getContent(),
+                        threadPool.absoluteTimeInMillis()))
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).request();
         indexRequest.setParentTask(clusterService.localNode().getId(), parentTask.getId());
         return indexRequest;

--- a/src/main/resources/querqy-mapping.json
+++ b/src/main/resources/querqy-mapping.json
@@ -4,6 +4,7 @@
       "type": {"type": "keyword"},
       "version": {"type":  "integer"},
       "revision": {"type": "keyword"},
+      "saved_at": {"type": "date"},
       "info_logging": {
         "properties": {
           "sinks": {"type" : "keyword" }

--- a/src/main/resources/querqy-mapping.json
+++ b/src/main/resources/querqy-mapping.json
@@ -3,6 +3,7 @@
       "class": {"type": "keyword"},
       "type": {"type": "keyword"},
       "version": {"type":  "integer"},
+      "revision": {"type": "keyword"},
       "info_logging": {
         "properties": {
           "sinks": {"type" : "keyword" }

--- a/src/test/java/querqy/opensearch/QuerqyMappingsUpdate1To4IntegrationTest.java
+++ b/src/test/java/querqy/opensearch/QuerqyMappingsUpdate1To4IntegrationTest.java
@@ -110,6 +110,7 @@ public class QuerqyMappingsUpdate1To4IntegrationTest extends OpenSearchSingleNod
         assertEquals(false, config_v_003_mapping.get("doc_values"));
 
         assertThat((Map<String, Object>) properties.get("revision"), hasEntry("type", "keyword"));
+        assertThat((Map<String, Object>) properties.get("saved_at"), hasEntry("type", "date"));
 
     }
 }

--- a/src/test/java/querqy/opensearch/QuerqyMappingsUpdate1To4IntegrationTest.java
+++ b/src/test/java/querqy/opensearch/QuerqyMappingsUpdate1To4IntegrationTest.java
@@ -41,7 +41,7 @@ import querqy.opensearch.rewriterstore.PutRewriterAction;
 import querqy.opensearch.rewriterstore.PutRewriterRequest;
 
 
-public class QuerqyMappingsUpdate1To3IntegrationTest extends OpenSearchSingleNodeTestCase {
+public class QuerqyMappingsUpdate1To4IntegrationTest extends OpenSearchSingleNodeTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
@@ -59,7 +59,7 @@ public class QuerqyMappingsUpdate1To3IntegrationTest extends OpenSearchSingleNod
     }
 
     @SuppressWarnings("unchecked")
-    public void testUpdate1To3() throws Exception {
+    public void testUpdate1To4() throws Exception {
 
         final String v1Mapping = "{\n" +
                 "    \"properties\": {\n" +
@@ -108,6 +108,8 @@ public class QuerqyMappingsUpdate1To3IntegrationTest extends OpenSearchSingleNod
         final Map<String, Object> config_v_003_mapping = (Map<String, Object>) properties.get("config_v_003");
         assertNotNull(config_v_003_mapping);
         assertEquals(false, config_v_003_mapping.get("doc_values"));
+
+        assertThat((Map<String, Object>) properties.get("revision"), hasEntry("type", "keyword"));
 
     }
 }

--- a/src/test/java/querqy/opensearch/QuerqyMappingsUpdate2To4IntegrationTest.java
+++ b/src/test/java/querqy/opensearch/QuerqyMappingsUpdate2To4IntegrationTest.java
@@ -40,7 +40,7 @@ import org.opensearch.transport.client.IndicesAdminClient;
 import querqy.opensearch.rewriterstore.PutRewriterAction;
 import querqy.opensearch.rewriterstore.PutRewriterRequest;
 
-public class QuerqyMappingsUpdate2To3IntegrationTest extends OpenSearchSingleNodeTestCase {
+public class QuerqyMappingsUpdate2To4IntegrationTest extends OpenSearchSingleNodeTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
@@ -58,7 +58,7 @@ public class QuerqyMappingsUpdate2To3IntegrationTest extends OpenSearchSingleNod
     }
 
     @SuppressWarnings("unchecked")
-    public void testUpdate2To3() throws Exception {
+    public void testUpdate2To4() throws Exception {
 
         final String v2Mapping = "{\n" +
                 "    \"properties\": {\n" +
@@ -112,6 +112,8 @@ public class QuerqyMappingsUpdate2To3IntegrationTest extends OpenSearchSingleNod
         final Map<String, Object> config_v_003_mapping = (Map<String, Object>) properties.get("config_v_003");
         assertNotNull(config_v_003_mapping);
         assertEquals(false, config_v_003_mapping.get("doc_values"));
+
+        assertThat((Map<String, Object>) properties.get("revision"), hasEntry("type", "keyword"));
 
     }
 }

--- a/src/test/java/querqy/opensearch/QuerqyMappingsUpdate2To4IntegrationTest.java
+++ b/src/test/java/querqy/opensearch/QuerqyMappingsUpdate2To4IntegrationTest.java
@@ -114,6 +114,7 @@ public class QuerqyMappingsUpdate2To4IntegrationTest extends OpenSearchSingleNod
         assertEquals(false, config_v_003_mapping.get("doc_values"));
 
         assertThat((Map<String, Object>) properties.get("revision"), hasEntry("type", "keyword"));
+        assertThat((Map<String, Object>) properties.get("saved_at"), hasEntry("type", "date"));
 
     }
 }

--- a/src/test/java/querqy/opensearch/QuerqyMappingsUpdate3To4IntegrationTest.java
+++ b/src/test/java/querqy/opensearch/QuerqyMappingsUpdate3To4IntegrationTest.java
@@ -114,12 +114,14 @@ public class QuerqyMappingsUpdate3To4IntegrationTest extends OpenSearchSingleNod
         assertNotNull(properties);
 
         assertThat((Map<String, Object>) properties.get("revision"), hasEntry("type", "keyword"));
+        assertThat((Map<String, Object>) properties.get("saved_at"), hasEntry("type", "date"));
 
         // the revision must have been saved in the new property and the hash must be derived from the config
         final RewriterInfo rewriter = client()
                 .execute(GetRewriterAction.INSTANCE, new GetRewriterRequest("common_rules")).get().getRewriter();
 
         assertEquals("release-2026-07-29", rewriter.getRevision());
+        assertNotNull(rewriter.getSavedAt());
         assertTrue("Not a SHA-256 hex string: " + rewriter.getConfigHash(),
                 rewriter.getConfigHash().matches("[0-9a-f]{64}"));
 

--- a/src/test/java/querqy/opensearch/QuerqyMappingsUpdate3To4IntegrationTest.java
+++ b/src/test/java/querqy/opensearch/QuerqyMappingsUpdate3To4IntegrationTest.java
@@ -1,0 +1,127 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2026 Querqy for OpenSearch Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package querqy.opensearch;
+
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
+import static querqy.opensearch.rewriterstore.Constants.QUERQY_INDEX_NAME;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.admin.indices.create.CreateIndexRequestBuilder;
+import org.opensearch.action.admin.indices.mapping.get.GetMappingsRequest;
+import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchSingleNodeTestCase;
+import org.opensearch.transport.client.IndicesAdminClient;
+import querqy.opensearch.rewriterstore.GetRewriterAction;
+import querqy.opensearch.rewriterstore.GetRewriterRequest;
+import querqy.opensearch.rewriterstore.PutRewriterAction;
+import querqy.opensearch.rewriterstore.PutRewriterRequest;
+import querqy.opensearch.rewriterstore.RewriterInfo;
+
+public class QuerqyMappingsUpdate3To4IntegrationTest extends OpenSearchSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Collections.singleton(QuerqyPlugin.class);
+    }
+
+
+    @After
+    public void deleteRewriterIndex() {
+        try {
+            client().admin().indices().prepareDelete(QUERQY_INDEX_NAME).get();
+        } catch (final IndexNotFoundException e) {
+            // Ignore
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testUpdate3To4() throws Exception {
+
+        final String v3Mapping = "{\n" +
+                "    \"properties\": {\n" +
+                "      \"class\": {\"type\": \"keyword\"},\n" +
+                "      \"type\": {\"type\": \"keyword\"},\n" +
+                "      \"version\": {\"type\":  \"integer\"},\n" +
+                "      \"info_logging\": {\n" +
+                "        \"properties\": {\n" +
+                "          \"sinks\": {\"type\" : \"keyword\" }\n" +
+                "        }\n" +
+                "      },\n" +
+                "      \"config\": {\n" +
+                "        \"type\" : \"keyword\",\n" +
+                "        \"index\": false\n" +
+                "      },\n" +
+                "      \"config_v_003\": {\n" +
+                "        \"type\" : \"keyword\",\n" +
+                "        \"doc_values\": false,\n" +
+                "        \"index\": false\n" +
+                "      }\n" +
+                "\n" +
+                "    }\n" +
+                "}";
+
+        final IndicesAdminClient indicesClient = client().admin().indices();
+
+        final CreateIndexRequestBuilder createIndexRequestBuilder = indicesClient.prepareCreate(QUERQY_INDEX_NAME);
+        final CreateIndexRequest createIndexRequest = createIndexRequestBuilder
+                .setMapping(v3Mapping).setSettings(Settings.builder().put("number_of_replicas", 2))
+                .request();
+        indicesClient.create(createIndexRequest).get();
+
+        final Map<String, Object> content = new HashMap<>();
+        content.put("class", querqy.opensearch.rewriter.SimpleCommonRulesRewriterFactory.class.getName());
+        content.put("revision", "release-2026-07-29");
+
+        final Map<String, Object> config = new HashMap<>();
+        config.put("rules", "k =>\nSYNONYM: c\n@_log: \"msg1\"");
+        config.put("ignoreCase", true);
+        config.put("querqyParser", querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory.class.getName());
+        content.put("config", config);
+
+        client().execute(PutRewriterAction.INSTANCE, new PutRewriterRequest("common_rules", content)).get();
+
+        final GetMappingsRequest getMappingsRequest = new GetMappingsRequest().indices(QUERQY_INDEX_NAME);
+        final Map<String, MappingMetadata> mappings = indicesClient
+                .getMappings(getMappingsRequest).get().getMappings();
+        final Map<String, Object> properties = (Map<String, Object>) mappings.get(QUERQY_INDEX_NAME)
+                .getSourceAsMap().get("properties");
+        assertNotNull(properties);
+
+        assertThat((Map<String, Object>) properties.get("revision"), hasEntry("type", "keyword"));
+
+        // the revision must have been saved in the new property and the hash must be derived from the config
+        final RewriterInfo rewriter = client()
+                .execute(GetRewriterAction.INSTANCE, new GetRewriterRequest("common_rules")).get().getRewriter();
+
+        assertEquals("release-2026-07-29", rewriter.getRevision());
+        assertTrue("Not a SHA-256 hex string: " + rewriter.getConfigHash(),
+                rewriter.getConfigHash().matches("[0-9a-f]{64}"));
+
+    }
+}

--- a/src/test/java/querqy/opensearch/RewriterConfigReadIntegrationTest.java
+++ b/src/test/java/querqy/opensearch/RewriterConfigReadIntegrationTest.java
@@ -35,6 +35,7 @@ import querqy.opensearch.rewriterstore.PutRewriterRequest;
 import querqy.opensearch.rewriterstore.RewriterInfo;
 import querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -78,6 +79,40 @@ public class RewriterConfigReadIntegrationTest extends OpenSearchSingleNodeTestC
         assertNotNull(config);
         assertEquals("k =>\n  SYNONYM: c", config.get("rules"));
         assertEquals(Boolean.TRUE, config.get("ignoreCase"));
+    }
+
+    public void testThatSavedAtIsSetByTheNodeThatSavesTheRewriter() throws Exception {
+
+        final long beforeSaving = System.currentTimeMillis();
+        putRewriter("common_rules", "k =>\n  SYNONYM: c", null);
+
+        final String savedAt = getRewriter("common_rules").getRewriter().getSavedAt();
+        assertNotNull(savedAt);
+
+        // the timestamp is taken from the node clock, which is only updated every couple of hundred milliseconds
+        final long savedAtMillis = Instant.parse(savedAt).toEpochMilli();
+        assertTrue("saved_at is not in the expected range: " + savedAt, savedAtMillis >= beforeSaving - 1000L);
+        assertTrue("saved_at is not in the expected range: " + savedAt,
+                savedAtMillis <= System.currentTimeMillis() + 1000L);
+    }
+
+    public void testThatSavedAtAdvancesWhenTheSameConfigIsSavedAgain() throws Exception {
+
+        putRewriter("common_rules", "k =>\n  SYNONYM: c", null);
+        final RewriterInfo firstSave = getRewriter("common_rules").getRewriter();
+
+        // The node clock has a granularity of a few hundred milliseconds, so saving again right away can leave the
+        // timestamp unchanged. Save until it has advanced instead of waiting for a fixed amount of time.
+        assertBusy(() -> {
+            putRewriter("common_rules", "k =>\n  SYNONYM: c", null);
+            final RewriterInfo laterSave = getRewriter("common_rules").getRewriter();
+
+            assertTrue("saved_at did not advance: " + laterSave.getSavedAt(),
+                    Instant.parse(laterSave.getSavedAt()).isAfter(Instant.parse(firstSave.getSavedAt())));
+
+            // the config didn't change, so its hash must not change either
+            assertEquals(firstSave.getConfigHash(), laterSave.getConfigHash());
+        });
     }
 
     public void testThatRevisionIsEmptyIfItWasNotSupplied() throws Exception {
@@ -146,6 +181,7 @@ public class RewriterConfigReadIntegrationTest extends OpenSearchSingleNodeTestC
         assertNull(rewriterA.getRevision());
         assertNull(rewriterA.getConfig());
         assertNotNull(rewriterA.getConfigHash());
+        assertNotNull(rewriterA.getSavedAt());
         assertEquals(SimpleCommonRulesRewriterFactory.class.getName(), rewriterA.getRewriterClassName());
 
         final RewriterInfo rewriterB = rewriters.get(1);

--- a/src/test/java/querqy/opensearch/RewriterConfigReadIntegrationTest.java
+++ b/src/test/java/querqy/opensearch/RewriterConfigReadIntegrationTest.java
@@ -1,0 +1,215 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2026 Querqy for OpenSearch Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package querqy.opensearch;
+
+import static querqy.opensearch.rewriterstore.Constants.QUERQY_INDEX_NAME;
+
+import org.junit.After;
+import org.opensearch.ResourceNotFoundException;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchSingleNodeTestCase;
+import querqy.opensearch.rewriter.SimpleCommonRulesRewriterFactory;
+import querqy.opensearch.rewriterstore.GetRewriterAction;
+import querqy.opensearch.rewriterstore.GetRewriterRequest;
+import querqy.opensearch.rewriterstore.GetRewriterResponse;
+import querqy.opensearch.rewriterstore.PutRewriterAction;
+import querqy.opensearch.rewriterstore.PutRewriterRequest;
+import querqy.opensearch.rewriterstore.RewriterInfo;
+import querqy.rewriter.commonrules.WhiteSpaceQuerqyParserFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+public class RewriterConfigReadIntegrationTest extends OpenSearchSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Collections.singleton(QuerqyPlugin.class);
+    }
+
+    @After
+    public void deleteRewriterIndex() {
+        try {
+            client().admin().indices().prepareDelete(QUERQY_INDEX_NAME).get();
+        } catch (final IndexNotFoundException e) {
+            // Ignore
+        }
+    }
+
+    public void testThatRewriterIsReturnedWithConfigRevisionAndHash() throws Exception {
+
+        putRewriter("common_rules", "k =>\n  SYNONYM: c", "release-2026-07-29");
+
+        final GetRewriterResponse response = getRewriter("common_rules");
+
+        assertNull(response.getRewriters());
+
+        final RewriterInfo rewriter = response.getRewriter();
+        assertNotNull(rewriter);
+        assertEquals("common_rules", rewriter.getRewriterId());
+        assertEquals(SimpleCommonRulesRewriterFactory.class.getName(), rewriter.getRewriterClassName());
+        assertEquals("release-2026-07-29", rewriter.getRevision());
+        assertTrue("Not a SHA-256 hex string: " + rewriter.getConfigHash(),
+                rewriter.getConfigHash().matches("[0-9a-f]{64}"));
+
+        final Map<String, Object> config = rewriter.getConfig();
+        assertNotNull(config);
+        assertEquals("k =>\n  SYNONYM: c", config.get("rules"));
+        assertEquals(Boolean.TRUE, config.get("ignoreCase"));
+    }
+
+    public void testThatRevisionIsEmptyIfItWasNotSupplied() throws Exception {
+
+        putRewriter("common_rules", "k =>\n  SYNONYM: c", null);
+
+        final RewriterInfo rewriter = getRewriter("common_rules").getRewriter();
+
+        assertNull(rewriter.getRevision());
+        assertNotNull(rewriter.getConfigHash());
+    }
+
+    public void testThatConfigHashOnlyDependsOnTheConfiguration() throws Exception {
+
+        putRewriter("rewriter1", "k =>\n  SYNONYM: c", "revision-1");
+        putRewriter("rewriter2", "k =>\n  SYNONYM: c", "revision-2");
+        putRewriter("rewriter3", "k =>\n  SYNONYM: d", null);
+
+        final String hash1 = getRewriter("rewriter1").getRewriter().getConfigHash();
+        final String hash2 = getRewriter("rewriter2").getRewriter().getConfigHash();
+        final String hash3 = getRewriter("rewriter3").getRewriter().getConfigHash();
+
+        // same configuration, different revision property
+        assertEquals(hash1, hash2);
+        // different rules
+        assertNotEquals(hash1, hash3);
+    }
+
+    public void testThatConfigHashCoversConfigPropertiesBesidesTheRules() throws Exception {
+
+        final String rules = "k =>\n  SYNONYM: c";
+
+        putRewriter("rewriter1", rules, true, "the-same-revision");
+        putRewriter("rewriter2", rules, false, "the-same-revision");
+
+        assertNotEquals(getRewriter("rewriter1").getRewriter().getConfigHash(),
+                getRewriter("rewriter2").getRewriter().getConfigHash());
+    }
+
+    public void testThatConfigHashDoesNotChangeWhenTheSameConfigIsSavedAgain() throws Exception {
+
+        putRewriter("common_rules", "k =>\n  SYNONYM: c", null);
+        final String hash = getRewriter("common_rules").getRewriter().getConfigHash();
+
+        putRewriter("common_rules", "k =>\n  SYNONYM: c", "a-new-revision");
+
+        assertEquals(hash, getRewriter("common_rules").getRewriter().getConfigHash());
+    }
+
+    public void testThatRewritersAreListedWithoutTheirConfig() throws Exception {
+
+        putRewriter("rewriter_b", "k =>\n  SYNONYM: c", "revision-b");
+        putRewriter("rewriter_a", "k =>\n  SYNONYM: d", null);
+
+        final GetRewriterResponse response = client()
+                .execute(GetRewriterAction.INSTANCE, new GetRewriterRequest()).get();
+
+        assertNull(response.getRewriter());
+
+        final List<RewriterInfo> rewriters = response.getRewriters();
+        assertEquals(2, rewriters.size());
+
+        // rewriters are listed in the order of their IDs
+        final RewriterInfo rewriterA = rewriters.get(0);
+        assertEquals("rewriter_a", rewriterA.getRewriterId());
+        assertNull(rewriterA.getRevision());
+        assertNull(rewriterA.getConfig());
+        assertNotNull(rewriterA.getConfigHash());
+        assertEquals(SimpleCommonRulesRewriterFactory.class.getName(), rewriterA.getRewriterClassName());
+
+        final RewriterInfo rewriterB = rewriters.get(1);
+        assertEquals("rewriter_b", rewriterB.getRewriterId());
+        assertEquals("revision-b", rewriterB.getRevision());
+        assertNull(rewriterB.getConfig());
+
+        // the hash of the listed rewriter must be the same as the one we get for the single rewriter
+        assertEquals(getRewriter("rewriter_b").getRewriter().getConfigHash(), rewriterB.getConfigHash());
+    }
+
+    public void testThatUnknownRewriterIsNotFound() throws Exception {
+
+        putRewriter("common_rules", "k =>\n  SYNONYM: c", null);
+
+        final ExecutionException executionException = expectThrows(ExecutionException.class,
+                () -> getRewriter("does_not_exist"));
+
+        assertTrue(executionException.getCause() instanceof ResourceNotFoundException);
+        assertEquals(RestStatus.NOT_FOUND, ((ResourceNotFoundException) executionException.getCause()).status());
+    }
+
+    public void testThatUnknownRewriterIsNotFoundIfRewriterIndexDoesNotExist() {
+
+        final ExecutionException executionException = expectThrows(ExecutionException.class,
+                () -> getRewriter("does_not_exist"));
+
+        assertTrue(executionException.getCause() instanceof ResourceNotFoundException);
+    }
+
+    public void testThatNoRewritersAreListedIfRewriterIndexDoesNotExist() throws Exception {
+
+        final GetRewriterResponse response = client()
+                .execute(GetRewriterAction.INSTANCE, new GetRewriterRequest()).get();
+
+        assertNull(response.getRewriter());
+        assertTrue(response.getRewriters().isEmpty());
+    }
+
+    private GetRewriterResponse getRewriter(final String rewriterId) throws Exception {
+        return client().execute(GetRewriterAction.INSTANCE, new GetRewriterRequest(rewriterId)).get();
+    }
+
+    private void putRewriter(final String rewriterId, final String rules, final String revision) throws Exception {
+        putRewriter(rewriterId, rules, true, revision);
+    }
+
+    private void putRewriter(final String rewriterId, final String rules, final boolean ignoreCase,
+                             final String revision) throws Exception {
+
+        final Map<String, Object> config = new HashMap<>();
+        config.put("rules", rules);
+        config.put("ignoreCase", ignoreCase);
+        config.put("querqyParser", WhiteSpaceQuerqyParserFactory.class.getName());
+
+        final Map<String, Object> content = new HashMap<>();
+        content.put("class", SimpleCommonRulesRewriterFactory.class.getName());
+        content.put("config", config);
+
+        if (revision != null) {
+            content.put("revision", revision);
+        }
+
+        client().execute(PutRewriterAction.INSTANCE, new PutRewriterRequest(rewriterId, content)).get();
+    }
+
+}

--- a/src/test/java/querqy/opensearch/rewriterstore/GetRewriterResponseTest.java
+++ b/src/test/java/querqy/opensearch/rewriterstore/GetRewriterResponseTest.java
@@ -36,6 +36,8 @@ import java.util.Map;
 
 public class GetRewriterResponseTest extends OpenSearchTestCase {
 
+    private static final String SAVED_AT = "2026-07-29T08:15:30.123Z";
+
     public void testThatStatusIsOk() {
         assertEquals(RestStatus.OK, new GetRewriterResponse(Collections.emptyList()).status());
         assertEquals(RestStatus.OK, new GetRewriterResponse(rewriterInfo("r1", "rev1", true)).status());
@@ -53,6 +55,7 @@ public class GetRewriterResponseTest extends OpenSearchTestCase {
         assertEquals("some.RewriterFactory", rewriter.getRewriterClassName());
         assertEquals("rev1", rewriter.getRevision());
         assertEquals("hash-of-r1", rewriter.getConfigHash());
+        assertEquals(SAVED_AT, rewriter.getSavedAt());
         assertEquals(config(), rewriter.getConfig());
         assertEquals(Collections.singletonMap("sinks", Collections.singletonList("log4j")),
                 rewriter.getInfoLoggingConfig());
@@ -61,11 +64,12 @@ public class GetRewriterResponseTest extends OpenSearchTestCase {
     public void testStreamSerializationOfRewriterWithoutOptionalProperties() throws IOException {
 
         final RewriterInfo rewriterInfo = new RewriterInfo("r1", "some.RewriterFactory", null, "hash-of-r1", null,
-                null);
+                null, null);
 
         final RewriterInfo deserialized = deserialize(new GetRewriterResponse(rewriterInfo)).getRewriter();
 
         assertNull(deserialized.getRevision());
+        assertNull(deserialized.getSavedAt());
         assertNull(deserialized.getConfig());
         assertNull(deserialized.getInfoLoggingConfig());
         assertEquals("hash-of-r1", deserialized.getConfigHash());
@@ -101,6 +105,7 @@ public class GetRewriterResponseTest extends OpenSearchTestCase {
         assertThat(rewriter, hasEntry("class", "some.RewriterFactory"));
         assertThat(rewriter, hasEntry(RewriterConfigMapping.PROP_REVISION, "rev1"));
         assertThat(rewriter, hasEntry(RewriterConfigMapping.PROP_CONFIG_HASH, "hash-of-r1"));
+        assertThat(rewriter, hasEntry(RewriterConfigMapping.PROP_SAVED_AT, SAVED_AT));
         assertEquals(config(), rewriter.get("config"));
         assertNotNull(rewriter.get("info_logging"));
     }
@@ -109,11 +114,12 @@ public class GetRewriterResponseTest extends OpenSearchTestCase {
     public void testThatOptionalPropertiesAreOmittedInJson() throws IOException {
 
         final Map<String, Object> parsed = toMap(new GetRewriterResponse(
-                new RewriterInfo("r1", "some.RewriterFactory", null, "hash-of-r1", null, null)));
+                new RewriterInfo("r1", "some.RewriterFactory", null, "hash-of-r1", null, null, null)));
 
         final Map<String, Object> rewriter = (Map<String, Object>) parsed.get(GetRewriterResponse.FIELD_REWRITER);
 
         assertFalse(rewriter.containsKey(RewriterConfigMapping.PROP_REVISION));
+        assertFalse(rewriter.containsKey(RewriterConfigMapping.PROP_SAVED_AT));
         assertFalse(rewriter.containsKey("config"));
         assertFalse(rewriter.containsKey("info_logging"));
         assertThat(rewriter, hasEntry(RewriterConfigMapping.PROP_CONFIG_HASH, "hash-of-r1"));
@@ -133,6 +139,7 @@ public class GetRewriterResponseTest extends OpenSearchTestCase {
 
         assertThat(rewriters.get(0), hasEntry(RewriterInfo.FIELD_REWRITER_ID, "r1"));
         assertThat(rewriters.get(0), hasEntry(RewriterConfigMapping.PROP_CONFIG_HASH, "hash-of-r1"));
+        assertThat(rewriters.get(0), hasEntry(RewriterConfigMapping.PROP_SAVED_AT, SAVED_AT));
         assertFalse(rewriters.get(0).containsKey("config"));
 
         assertThat(rewriters.get(1), hasEntry(RewriterInfo.FIELD_REWRITER_ID, "r2"));
@@ -155,7 +162,7 @@ public class GetRewriterResponseTest extends OpenSearchTestCase {
     private static RewriterInfo rewriterInfo(final String rewriterId, final String revision,
                                             final boolean includeConfig) {
         return new RewriterInfo(rewriterId, "some.RewriterFactory", revision, "hash-of-" + rewriterId,
-                includeConfig ? config() : null,
+                SAVED_AT, includeConfig ? config() : null,
                 Collections.singletonMap("sinks", Collections.singletonList("log4j")));
     }
 

--- a/src/test/java/querqy/opensearch/rewriterstore/GetRewriterResponseTest.java
+++ b/src/test/java/querqy/opensearch/rewriterstore/GetRewriterResponseTest.java
@@ -1,0 +1,169 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2026 Querqy for OpenSearch Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package querqy.opensearch.rewriterstore;
+
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class GetRewriterResponseTest extends OpenSearchTestCase {
+
+    public void testThatStatusIsOk() {
+        assertEquals(RestStatus.OK, new GetRewriterResponse(Collections.emptyList()).status());
+        assertEquals(RestStatus.OK, new GetRewriterResponse(rewriterInfo("r1", "rev1", true)).status());
+    }
+
+    public void testStreamSerializationOfSingleRewriter() throws IOException {
+
+        final GetRewriterResponse response = deserialize(new GetRewriterResponse(rewriterInfo("r1", "rev1", true)));
+
+        assertNull(response.getRewriters());
+
+        final RewriterInfo rewriter = response.getRewriter();
+        assertNotNull(rewriter);
+        assertEquals("r1", rewriter.getRewriterId());
+        assertEquals("some.RewriterFactory", rewriter.getRewriterClassName());
+        assertEquals("rev1", rewriter.getRevision());
+        assertEquals("hash-of-r1", rewriter.getConfigHash());
+        assertEquals(config(), rewriter.getConfig());
+        assertEquals(Collections.singletonMap("sinks", Collections.singletonList("log4j")),
+                rewriter.getInfoLoggingConfig());
+    }
+
+    public void testStreamSerializationOfRewriterWithoutOptionalProperties() throws IOException {
+
+        final RewriterInfo rewriterInfo = new RewriterInfo("r1", "some.RewriterFactory", null, "hash-of-r1", null,
+                null);
+
+        final RewriterInfo deserialized = deserialize(new GetRewriterResponse(rewriterInfo)).getRewriter();
+
+        assertNull(deserialized.getRevision());
+        assertNull(deserialized.getConfig());
+        assertNull(deserialized.getInfoLoggingConfig());
+        assertEquals("hash-of-r1", deserialized.getConfigHash());
+    }
+
+    public void testStreamSerializationOfRewriterList() throws IOException {
+
+        final GetRewriterResponse response = deserialize(new GetRewriterResponse(
+                Arrays.asList(rewriterInfo("r1", "rev1", false), rewriterInfo("r2", null, false))));
+
+        assertNull(response.getRewriter());
+
+        final List<RewriterInfo> rewriters = response.getRewriters();
+        assertEquals(2, rewriters.size());
+        assertEquals("r1", rewriters.get(0).getRewriterId());
+        assertEquals("rev1", rewriters.get(0).getRevision());
+        assertEquals("r2", rewriters.get(1).getRewriterId());
+        assertNull(rewriters.get(1).getRevision());
+        assertNull(rewriters.get(1).getConfig());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testToJsonForSingleRewriter() throws IOException {
+
+        final Map<String, Object> parsed = toMap(new GetRewriterResponse(rewriterInfo("r1", "rev1", true)));
+
+        assertEquals(1, parsed.size());
+
+        final Map<String, Object> rewriter = (Map<String, Object>) parsed.get(GetRewriterResponse.FIELD_REWRITER);
+        assertNotNull(rewriter);
+
+        assertThat(rewriter, hasEntry(RewriterInfo.FIELD_REWRITER_ID, "r1"));
+        assertThat(rewriter, hasEntry("class", "some.RewriterFactory"));
+        assertThat(rewriter, hasEntry(RewriterConfigMapping.PROP_REVISION, "rev1"));
+        assertThat(rewriter, hasEntry(RewriterConfigMapping.PROP_CONFIG_HASH, "hash-of-r1"));
+        assertEquals(config(), rewriter.get("config"));
+        assertNotNull(rewriter.get("info_logging"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testThatOptionalPropertiesAreOmittedInJson() throws IOException {
+
+        final Map<String, Object> parsed = toMap(new GetRewriterResponse(
+                new RewriterInfo("r1", "some.RewriterFactory", null, "hash-of-r1", null, null)));
+
+        final Map<String, Object> rewriter = (Map<String, Object>) parsed.get(GetRewriterResponse.FIELD_REWRITER);
+
+        assertFalse(rewriter.containsKey(RewriterConfigMapping.PROP_REVISION));
+        assertFalse(rewriter.containsKey("config"));
+        assertFalse(rewriter.containsKey("info_logging"));
+        assertThat(rewriter, hasEntry(RewriterConfigMapping.PROP_CONFIG_HASH, "hash-of-r1"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testToJsonForRewriterList() throws IOException {
+
+        final Map<String, Object> parsed = toMap(new GetRewriterResponse(
+                Arrays.asList(rewriterInfo("r1", "rev1", false), rewriterInfo("r2", null, false))));
+
+        assertEquals(1, parsed.size());
+
+        final List<Map<String, Object>> rewriters = (List<Map<String, Object>>) parsed
+                .get(GetRewriterResponse.FIELD_REWRITERS);
+        assertEquals(2, rewriters.size());
+
+        assertThat(rewriters.get(0), hasEntry(RewriterInfo.FIELD_REWRITER_ID, "r1"));
+        assertThat(rewriters.get(0), hasEntry(RewriterConfigMapping.PROP_CONFIG_HASH, "hash-of-r1"));
+        assertFalse(rewriters.get(0).containsKey("config"));
+
+        assertThat(rewriters.get(1), hasEntry(RewriterInfo.FIELD_REWRITER_ID, "r2"));
+        assertFalse(rewriters.get(1).containsKey(RewriterConfigMapping.PROP_REVISION));
+    }
+
+    private static GetRewriterResponse deserialize(final GetRewriterResponse response) throws IOException {
+        final BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+        output.flush();
+        return new GetRewriterResponse(output.bytes().streamInput());
+    }
+
+    private static Map<String, Object> toMap(final GetRewriterResponse response) throws IOException {
+        try (InputStream stream = XContentHelper.toXContent(response, XContentType.JSON, true).streamInput()) {
+            return XContentHelper.convertToMap(XContentType.JSON.xContent(), stream, false);
+        }
+    }
+
+    private static RewriterInfo rewriterInfo(final String rewriterId, final String revision,
+                                            final boolean includeConfig) {
+        return new RewriterInfo(rewriterId, "some.RewriterFactory", revision, "hash-of-" + rewriterId,
+                includeConfig ? config() : null,
+                Collections.singletonMap("sinks", Collections.singletonList("log4j")));
+    }
+
+    private static Map<String, Object> config() {
+        final Map<String, Object> config = new LinkedHashMap<>();
+        config.put("rules", "k =>\nSYNONYM: c");
+        config.put("ignoreCase", true);
+        return config;
+    }
+
+}

--- a/src/test/java/querqy/opensearch/rewriterstore/PutRewriterRequestTest.java
+++ b/src/test/java/querqy/opensearch/rewriterstore/PutRewriterRequestTest.java
@@ -74,6 +74,42 @@ public class PutRewriterRequestTest extends OpenSearchTestCase {
 
     }
 
+    public void testValidRevision() {
+
+        final Map<String, Object> content = new HashMap<>();
+        content.put("class", DummyOpenSearchRewriterFactory.class.getName());
+        content.put("config", new HashMap<String, Object>());
+        content.put("revision", "release-2026-07-29");
+
+        assertNull(new PutRewriterRequest("r8", content).validate());
+    }
+
+    public void testThatNonStringRevisionIsRejected() {
+
+        final Map<String, Object> content = new HashMap<>();
+        content.put("class", DummyOpenSearchRewriterFactory.class.getName());
+        content.put("config", new HashMap<String, Object>());
+        content.put("revision", 42);
+
+        final ActionRequestValidationException validationResult = new PutRewriterRequest("r8", content).validate();
+        assertNotNull(validationResult);
+        assertThat(validationResult.validationErrors(),
+                Matchers.contains(Matchers.containsString("'revision' must be a string")));
+    }
+
+    public void testThatEmptyRevisionIsRejected() {
+
+        final Map<String, Object> content = new HashMap<>();
+        content.put("class", DummyOpenSearchRewriterFactory.class.getName());
+        content.put("config", new HashMap<String, Object>());
+        content.put("revision", " ");
+
+        final ActionRequestValidationException validationResult = new PutRewriterRequest("r8", content).validate();
+        assertNotNull(validationResult);
+        assertThat(validationResult.validationErrors(),
+                Matchers.contains(Matchers.containsString("'revision' must not be empty")));
+    }
+
     public void testStreamSerialization() throws IOException {
 
         final Map<String, Object> content = new HashMap<>();

--- a/src/test/java/querqy/opensearch/rewriterstore/RestGetRewriterActionTest.java
+++ b/src/test/java/querqy/opensearch/rewriterstore/RestGetRewriterActionTest.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2026 Querqy for OpenSearch Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package querqy.opensearch.rewriterstore;
+
+import static org.mockito.Mockito.mock;
+import static querqy.opensearch.rewriterstore.Constants.QUERQY_REWRITER_BASE_ROUTE;
+import static querqy.opensearch.rewriterstore.RestGetRewriterAction.PARAM_REWRITER_ID;
+
+import org.opensearch.rest.RestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class RestGetRewriterActionTest extends OpenSearchTestCase {
+
+    public void testThatRewriterIdIsParsed() {
+
+        final GetRewriterRequest request = createRequest(Collections.singletonMap(PARAM_REWRITER_ID, "rewriter1"));
+        assertEquals("rewriter1", request.getRewriterId());
+    }
+
+    public void testThatRewriterIdIsTrimmed() {
+
+        final GetRewriterRequest request = createRequest(Collections.singletonMap(PARAM_REWRITER_ID, " rewriter1 "));
+        assertEquals("rewriter1", request.getRewriterId());
+    }
+
+    public void testThatMissingRewriterIdRequestsAllRewriters() {
+
+        final GetRewriterRequest request = createRequest(Collections.emptyMap());
+        assertNull(request.getRewriterId());
+    }
+
+    public void testThatEmptyRewriterIdRequestsAllRewriters() {
+
+        final GetRewriterRequest request = createRequest(Collections.singletonMap(PARAM_REWRITER_ID, " "));
+        assertNull(request.getRewriterId());
+    }
+
+    public void testRoutes() {
+
+        final List<RestHandler.Route> routes = new RestGetRewriterAction().routes();
+        assertEquals(2, routes.size());
+
+        for (final RestHandler.Route route : routes) {
+            assertEquals(RestRequest.Method.GET, route.getMethod());
+        }
+
+        assertEquals(QUERQY_REWRITER_BASE_ROUTE, routes.get(0).getPath());
+        assertEquals(QUERQY_REWRITER_BASE_ROUTE + "/{rewriterId}", routes.get(1).getPath());
+    }
+
+    private static GetRewriterRequest createRequest(final Map<String, String> params) {
+
+        final NodeClient client = mock(NodeClient.class);
+        final FakeRestRequest restRequest = new FakeRestRequest.Builder(null)
+                .withParams(new HashMap<>(params)).build();
+
+        return new RestGetRewriterAction().createRequestBuilder(restRequest, client).request();
+    }
+
+}

--- a/src/test/java/querqy/opensearch/rewriterstore/RewriterConfigMappingTest.java
+++ b/src/test/java/querqy/opensearch/rewriterstore/RewriterConfigMappingTest.java
@@ -44,6 +44,9 @@ public class RewriterConfigMappingTest extends OpenSearchTestCase {
 
     private static final String CLASS_NAME = "querqy.opensearch.DummyOpenSearchRewriterFactory";
 
+    /** 2026-07-29T08:15:30.123Z */
+    private static final long SAVED_AT_MILLIS = 1785312930123L;
+
     public void testStringToSourceValue() {
         String s = "123456789ä";
         if (new BytesRef(s).length != 11) {
@@ -86,7 +89,7 @@ public class RewriterConfigMappingTest extends OpenSearchTestCase {
 
     public void testThatDocumentIsSavedWithCurrentMappingVersion() throws IOException {
 
-        final Map<String, Object> source = RewriterConfigMapping.toLuceneSource(putContent(config(), null));
+        final Map<String, Object> source = toLuceneSource(putContent(config(), null));
 
         assertEquals(CURRENT_MAPPING_VERSION, source.get(PROP_VERSION));
         assertEquals("rewriter", source.get(PROP_TYPE));
@@ -95,7 +98,7 @@ public class RewriterConfigMappingTest extends OpenSearchTestCase {
 
     public void testThatConfigIsStoredCanonically() throws IOException {
 
-        final String stored = (String) RewriterConfigMapping.toLuceneSource(putContent(config(), null))
+        final String stored = (String) toLuceneSource(putContent(config(), null))
                 .get(CURRENT.getConfigStringProperty());
 
         assertEquals("{\"a\":{\"c\":3,\"d\":2},\"b\":1,\"list\":[\"x\",\"y\"]}", stored);
@@ -103,9 +106,9 @@ public class RewriterConfigMappingTest extends OpenSearchTestCase {
 
     public void testThatCanonicalConfigDoesNotDependOnPropertyOrder() throws IOException {
 
-        final Object stored1 = RewriterConfigMapping.toLuceneSource(putContent(config(), null))
+        final Object stored1 = toLuceneSource(putContent(config(), null))
                 .get(CURRENT.getConfigStringProperty());
-        final Object stored2 = RewriterConfigMapping.toLuceneSource(putContent(configInDifferentOrder(), null))
+        final Object stored2 = toLuceneSource(putContent(configInDifferentOrder(), null))
                 .get(CURRENT.getConfigStringProperty());
 
         assertEquals(stored1, stored2);
@@ -113,8 +116,7 @@ public class RewriterConfigMappingTest extends OpenSearchTestCase {
 
     public void testThatRevisionIsSavedAndRead() throws IOException {
 
-        final Map<String, Object> source = RewriterConfigMapping
-                .toLuceneSource(putContent(config(), "release-2026-07-29"));
+        final Map<String, Object> source = toLuceneSource(putContent(config(), "release-2026-07-29"));
 
         assertEquals("release-2026-07-29", source.get(PROP_REVISION));
         assertEquals("release-2026-07-29", getMapping(source).getRevision(source));
@@ -122,7 +124,7 @@ public class RewriterConfigMappingTest extends OpenSearchTestCase {
 
     public void testThatRevisionIsNotSavedIfItWasNotSupplied() throws IOException {
 
-        final Map<String, Object> source = RewriterConfigMapping.toLuceneSource(putContent(config(), null));
+        final Map<String, Object> source = toLuceneSource(putContent(config(), null));
 
         assertFalse(source.containsKey(PROP_REVISION));
         assertNull(getMapping(source).getRevision(source));
@@ -183,7 +185,7 @@ public class RewriterConfigMappingTest extends OpenSearchTestCase {
 
     public void testThatConfigHashOfV3DocumentEqualsHashOfCurrentDocument() throws IOException {
 
-        final Map<String, Object> v4Source = RewriterConfigMapping.toLuceneSource(putContent(config(), null));
+        final Map<String, Object> v4Source = toLuceneSource(putContent(config(), null));
 
         // a document as it was saved by mapping version 3: the config was not stored in canonical form
         final Map<String, Object> v3Source = new HashMap<>();
@@ -205,8 +207,8 @@ public class RewriterConfigMappingTest extends OpenSearchTestCase {
             rules.append("k").append(rules.length()).append(" =>\n  SYNONYM: c\n");
         }
 
-        final Map<String, Object> source = RewriterConfigMapping
-                .toLuceneSource(putContent(Collections.singletonMap("rules", rules.toString()), null));
+        final Map<String, Object> source = toLuceneSource(
+                putContent(Collections.singletonMap("rules", rules.toString()), null));
 
         final Object configValue = source.get(CURRENT.getConfigStringProperty());
         if (!(configValue instanceof String[])) {
@@ -237,14 +239,66 @@ public class RewriterConfigMappingTest extends OpenSearchTestCase {
 
     public void testThatConfigCanBeReadBackFromCanonicalDocument() throws IOException {
 
-        final Map<String, Object> source = RewriterConfigMapping.toLuceneSource(putContent(config(), null));
+        final Map<String, Object> source = toLuceneSource(putContent(config(), null));
 
         assertEquals(config(), getMapping(source).getConfig("r1", source));
     }
 
+    public void testThatSavedAtIsSavedAsIso8601() throws IOException {
+
+        final Map<String, Object> source = toLuceneSource(putContent(config(), null));
+
+        assertEquals("2026-07-29T08:15:30.123Z", source.get(RewriterConfigMapping.PROP_SAVED_AT));
+        assertEquals("2026-07-29T08:15:30.123Z", getMapping(source).getSavedAt(source));
+    }
+
+    public void testThatSavedAtIsNotSavedIfNoTimestampIsSupplied() throws IOException {
+
+        final Map<String, Object> source = RewriterConfigMapping.toLuceneSource(putContent(config(), null), null);
+
+        assertFalse(source.containsKey(RewriterConfigMapping.PROP_SAVED_AT));
+        assertNull(getMapping(source).getSavedAt(source));
+    }
+
+    public void testThatSavedAtSuppliedByTheUserIsIgnored() throws IOException {
+
+        final Map<String, Object> content = putContent(config(), null);
+        content.put(RewriterConfigMapping.PROP_SAVED_AT, "1970-01-01T00:00:00Z");
+
+        assertEquals("2026-07-29T08:15:30.123Z",
+                toLuceneSource(content).get(RewriterConfigMapping.PROP_SAVED_AT));
+    }
+
+    public void testThatSavedAtIsReadFromEpochMillis() {
+
+        // the date field type also accepts epoch millis, which we could see in a document that wasn't written by the
+        // rewriter API
+        final Map<String, Object> source = new HashMap<>();
+        source.put(PROP_VERSION, CURRENT_MAPPING_VERSION);
+        source.put(RewriterConfigMapping.PROP_SAVED_AT, SAVED_AT_MILLIS);
+
+        assertEquals("2026-07-29T08:15:30.123Z", CURRENT.getSavedAt(source));
+    }
+
+    public void testThatConfigHashDoesNotDependOnSavedAt() throws IOException {
+
+        final Map<String, Object> source1 = RewriterConfigMapping
+                .toLuceneSource(putContent(config(), null), SAVED_AT_MILLIS);
+        final Map<String, Object> source2 = RewriterConfigMapping
+                .toLuceneSource(putContent(config(), null), SAVED_AT_MILLIS + 86_400_000L);
+
+        assertNotEquals(source1.get(RewriterConfigMapping.PROP_SAVED_AT),
+                source2.get(RewriterConfigMapping.PROP_SAVED_AT));
+        assertEquals(CURRENT.computeConfigHash("r1", source1), CURRENT.computeConfigHash("r1", source2));
+    }
+
     private static String configHashOf(final Map<String, Object> putRequestContent) throws IOException {
-        final Map<String, Object> source = RewriterConfigMapping.toLuceneSource(putRequestContent);
+        final Map<String, Object> source = toLuceneSource(putRequestContent);
         return getMapping(source).computeConfigHash("r1", source);
+    }
+
+    private static Map<String, Object> toLuceneSource(final Map<String, Object> putRequestContent) throws IOException {
+        return RewriterConfigMapping.toLuceneSource(putRequestContent, SAVED_AT_MILLIS);
     }
 
     private static Map<String, Object> putContent(final Map<String, Object> config, final String revision) {

--- a/src/test/java/querqy/opensearch/rewriterstore/RewriterConfigMappingTest.java
+++ b/src/test/java/querqy/opensearch/rewriterstore/RewriterConfigMappingTest.java
@@ -18,15 +18,31 @@
 
 package querqy.opensearch.rewriterstore;
 
+import static querqy.opensearch.rewriterstore.RewriterConfigMapping.CURRENT;
+import static querqy.opensearch.rewriterstore.RewriterConfigMapping.CURRENT_MAPPING_VERSION;
+import static querqy.opensearch.rewriterstore.RewriterConfigMapping.PROP_REVISION;
+import static querqy.opensearch.rewriterstore.RewriterConfigMapping.PROP_TYPE;
+import static querqy.opensearch.rewriterstore.RewriterConfigMapping.PROP_VERSION;
+import static querqy.opensearch.rewriterstore.RewriterConfigMapping.PRE3_MAPPING;
+import static querqy.opensearch.rewriterstore.RewriterConfigMapping.V3_MAPPING;
+import static querqy.opensearch.rewriterstore.RewriterConfigMapping.getMapping;
+
 import org.opensearch.test.OpenSearchTestCase;
 import org.apache.lucene.util.BytesRef;
 import org.hamcrest.Matchers;
 import static org.hamcrest.Matchers.everyItem;
 
+import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class RewriterConfigMappingTest extends OpenSearchTestCase {
+
+    private static final String CLASS_NAME = "querqy.opensearch.DummyOpenSearchRewriterFactory";
 
     public void testStringToSourceValue() {
         String s = "123456789ä";
@@ -56,6 +72,226 @@ public class RewriterConfigMappingTest extends OpenSearchTestCase {
 
     public void testStringToSourceValueWithIllegalLimit() {
         expectThrows(IllegalArgumentException.class, () -> RewriterConfigMapping.stringToSourceValue("12345", 2));
+    }
+
+    public void testThatMappingIsSelectedByVersion() {
+
+        assertSame(PRE3_MAPPING, getMapping(Collections.emptyMap()));
+        assertSame(V3_MAPPING, getMapping(Collections.singletonMap(PROP_VERSION, 3)));
+        assertSame(CURRENT, getMapping(Collections.singletonMap(PROP_VERSION, 4)));
+
+        expectThrows(IllegalArgumentException.class,
+                () -> getMapping(Collections.singletonMap(PROP_VERSION, CURRENT_MAPPING_VERSION + 1)));
+    }
+
+    public void testThatDocumentIsSavedWithCurrentMappingVersion() throws IOException {
+
+        final Map<String, Object> source = RewriterConfigMapping.toLuceneSource(putContent(config(), null));
+
+        assertEquals(CURRENT_MAPPING_VERSION, source.get(PROP_VERSION));
+        assertEquals("rewriter", source.get(PROP_TYPE));
+        assertSame(CURRENT, getMapping(source));
+    }
+
+    public void testThatConfigIsStoredCanonically() throws IOException {
+
+        final String stored = (String) RewriterConfigMapping.toLuceneSource(putContent(config(), null))
+                .get(CURRENT.getConfigStringProperty());
+
+        assertEquals("{\"a\":{\"c\":3,\"d\":2},\"b\":1,\"list\":[\"x\",\"y\"]}", stored);
+    }
+
+    public void testThatCanonicalConfigDoesNotDependOnPropertyOrder() throws IOException {
+
+        final Object stored1 = RewriterConfigMapping.toLuceneSource(putContent(config(), null))
+                .get(CURRENT.getConfigStringProperty());
+        final Object stored2 = RewriterConfigMapping.toLuceneSource(putContent(configInDifferentOrder(), null))
+                .get(CURRENT.getConfigStringProperty());
+
+        assertEquals(stored1, stored2);
+    }
+
+    public void testThatRevisionIsSavedAndRead() throws IOException {
+
+        final Map<String, Object> source = RewriterConfigMapping
+                .toLuceneSource(putContent(config(), "release-2026-07-29"));
+
+        assertEquals("release-2026-07-29", source.get(PROP_REVISION));
+        assertEquals("release-2026-07-29", getMapping(source).getRevision(source));
+    }
+
+    public void testThatRevisionIsNotSavedIfItWasNotSupplied() throws IOException {
+
+        final Map<String, Object> source = RewriterConfigMapping.toLuceneSource(putContent(config(), null));
+
+        assertFalse(source.containsKey(PROP_REVISION));
+        assertNull(getMapping(source).getRevision(source));
+    }
+
+    public void testThatConfigHashDoesNotDependOnPropertyOrder() throws IOException {
+
+        assertEquals(configHashOf(putContent(config(), null)),
+                configHashOf(putContent(configInDifferentOrder(), null)));
+    }
+
+    public void testThatConfigHashDoesNotDependOnRevision() throws IOException {
+
+        assertEquals(configHashOf(putContent(config(), null)),
+                configHashOf(putContent(config(), "release-2026-07-29")));
+    }
+
+    public void testThatConfigHashChangesWithConfig() throws IOException {
+
+        final Map<String, Object> changedConfig = config();
+        changedConfig.put("b", 2);
+
+        assertNotEquals(configHashOf(putContent(config(), null)), configHashOf(putContent(changedConfig, null)));
+    }
+
+    public void testThatConfigHashChangesWithListOrder() throws IOException {
+
+        final Map<String, Object> changedConfig = config();
+        changedConfig.put("list", Arrays.asList("y", "x"));
+
+        assertNotEquals(configHashOf(putContent(config(), null)), configHashOf(putContent(changedConfig, null)));
+    }
+
+    public void testThatConfigHashChangesWithRewriterClass() throws IOException {
+
+        final Map<String, Object> content = putContent(config(), null);
+        content.put("class", CLASS_NAME + "2");
+
+        assertNotEquals(configHashOf(putContent(config(), null)), configHashOf(content));
+    }
+
+    public void testThatConfigHashChangesWithInfoLoggingConfig() throws IOException {
+
+        final Map<String, Object> content = putContent(config(), null);
+        content.put("info_logging", Collections.singletonMap("sinks", Collections.singletonList("log4j")));
+
+        assertNotEquals(configHashOf(putContent(config(), null)), configHashOf(content));
+    }
+
+    public void testThatConfigHashIsIndependentOfConfigAbsence() throws IOException {
+
+        // a rewriter without any config must still produce a hash, and a different one than a rewriter with a config
+        final String hashWithoutConfig = configHashOf(putContent(null, null));
+
+        assertNotNull(hashWithoutConfig);
+        assertNotEquals(hashWithoutConfig, configHashOf(putContent(config(), null)));
+    }
+
+    public void testThatConfigHashOfV3DocumentEqualsHashOfCurrentDocument() throws IOException {
+
+        final Map<String, Object> v4Source = RewriterConfigMapping.toLuceneSource(putContent(config(), null));
+
+        // a document as it was saved by mapping version 3: the config was not stored in canonical form
+        final Map<String, Object> v3Source = new HashMap<>();
+        v3Source.put(PROP_TYPE, "rewriter");
+        v3Source.put(PROP_VERSION, 3);
+        v3Source.put("class", CLASS_NAME);
+        v3Source.put(V3_MAPPING.getConfigStringProperty(),
+                "{\"b\": 1, \"list\": [\"x\", \"y\"], \"a\": {\"d\": 2, \"c\": 3}}");
+
+        assertSame(V3_MAPPING, getMapping(v3Source));
+        assertEquals(getMapping(v4Source).computeConfigHash("r1", v4Source),
+                getMapping(v3Source).computeConfigHash("r1", v3Source));
+    }
+
+    public void testThatConfigHashIsComputedForConfigThatHadToBeSplitUp() throws IOException {
+
+        final StringBuilder rules = new StringBuilder();
+        while (rules.length() < 40000) {
+            rules.append("k").append(rules.length()).append(" =>\n  SYNONYM: c\n");
+        }
+
+        final Map<String, Object> source = RewriterConfigMapping
+                .toLuceneSource(putContent(Collections.singletonMap("rules", rules.toString()), null));
+
+        final Object configValue = source.get(CURRENT.getConfigStringProperty());
+        if (!(configValue instanceof String[])) {
+            throw new IllegalStateException("Test assumptions are wrong: config was not split up");
+        }
+
+        final String hashOfSplitConfig = CURRENT.computeConfigHash("r1", source);
+
+        // the hash must not depend on how the config was split up...
+        final Map<String, Object> unsplitSource = new HashMap<>(source);
+        unsplitSource.put(CURRENT.getConfigStringProperty(), String.join("", (String[]) configValue));
+        assertEquals(CURRENT.computeConfigHash("r1", unsplitSource), hashOfSplitConfig);
+
+        // ... and not on whether the document was just built or read back from the index, where the parts of the
+        // config arrive as a List
+        final Map<String, Object> sourceFromIndex = new HashMap<>(source);
+        sourceFromIndex.put(CURRENT.getConfigStringProperty(), Arrays.asList((String[]) configValue));
+        assertEquals(CURRENT.computeConfigHash("r1", sourceFromIndex), hashOfSplitConfig);
+    }
+
+    public void testThatConfigHashIsAHexEncodedSha256() throws IOException {
+
+        final String hash = configHashOf(putContent(config(), null));
+
+        assertEquals(64, hash.length());
+        assertTrue("Not a lower-case hex string: " + hash, hash.matches("[0-9a-f]{64}"));
+    }
+
+    public void testThatConfigCanBeReadBackFromCanonicalDocument() throws IOException {
+
+        final Map<String, Object> source = RewriterConfigMapping.toLuceneSource(putContent(config(), null));
+
+        assertEquals(config(), getMapping(source).getConfig("r1", source));
+    }
+
+    private static String configHashOf(final Map<String, Object> putRequestContent) throws IOException {
+        final Map<String, Object> source = RewriterConfigMapping.toLuceneSource(putRequestContent);
+        return getMapping(source).computeConfigHash("r1", source);
+    }
+
+    private static Map<String, Object> putContent(final Map<String, Object> config, final String revision) {
+
+        final Map<String, Object> content = new LinkedHashMap<>();
+        content.put("class", CLASS_NAME);
+
+        if (config != null) {
+            content.put("config", config);
+        }
+
+        if (revision != null) {
+            content.put(PROP_REVISION, revision);
+        }
+
+        return content;
+    }
+
+    private static Map<String, Object> config() {
+
+        final Map<String, Object> nested = new LinkedHashMap<>();
+        nested.put("d", 2);
+        nested.put("c", 3);
+
+        final Map<String, Object> config = new LinkedHashMap<>();
+        config.put("b", 1);
+        config.put("a", nested);
+        config.put("list", Arrays.asList("x", "y"));
+
+        return config;
+    }
+
+    /**
+     * @return The same config as {@link #config()} but with the properties of all objects in a different order
+     */
+    private static Map<String, Object> configInDifferentOrder() {
+
+        final Map<String, Object> nested = new LinkedHashMap<>();
+        nested.put("c", 3);
+        nested.put("d", 2);
+
+        final Map<String, Object> config = new LinkedHashMap<>();
+        config.put("list", Arrays.asList("x", "y"));
+        config.put("a", nested);
+        config.put("b", 1);
+
+        return config;
     }
 
 }


### PR DESCRIPTION
Closes #167

Adds endpoints to read rewriter configurations and three new properties that identify and date a configuration.

## Reading rewriter configurations

* `GET /_plugins/_querqy/rewriter` lists all rewriters with `rewriter_id`, `class`, `revision`, `config_hash` and `saved_at`, ordered by rewriter ID. The configuration itself is not included, as it can be several megabytes.
* `GET /_plugins/_querqy/rewriter/<rewriter_id>` returns a single rewriter including its configuration. An unknown ID yields a 404, a missing `.opensearch-querqy` index yields an empty list rather than an error.

The single-rewriter response is shaped like the payload of a PUT request so that it can be fed back into one, for example to copy a rewriter from one cluster to another:

```json
{
  "rewriter": {
    "rewriter_id": "common_rules",
    "class": "querqy.opensearch.rewriter.SimpleCommonRulesRewriterFactory",
    "revision": "release-2026-07-29",
    "config_hash": "9b1c...",
    "saved_at": "2026-07-29T08:15:30.123Z",
    "config": { "rules": "..." },
    "info_logging": { "sinks": ["log4j"] }
  }
}
```

## New properties

* **`revision`** – optional, an arbitrary string supplied by the user (a git SHA, a release tag, ...). Stored as a `keyword`, must be a non-empty string, not interpreted in any way. Omitted from responses when it wasn't set.
* **`config_hash`** – a SHA-256 hash over the rewriter class, the config and the info logging config, as a lower-case hex string. It is **derived on read and never stored**, so it cannot go stale when a rewriter document is written without the rewriter API (bulk indexing, reindexing, restoring a snapshot). To keep deriving it cheap, configurations are now stored in canonical form (recursively key-sorted), which also removes `HashMap` iteration order as a source of non-deterministic hashes. Documents from earlier mapping versions use a parse-and-canonicalize fallback and produce the same hash for the same content.
* **`saved_at`** – when the configuration was saved, set by the node that receives the request from `ThreadPool.absoluteTimeInMillis()`. Saved and returned as an ISO-8601 timestamp in UTC and mapped as a `date`, so it can be searched and sorted on in the rewriter index. This identifies rewriters that nobody has touched in a long time.

`revision` and `config_hash` are deliberately separate properties: collapsing them would make it impossible to tell a user-supplied label apart from a generated content hash. `saved_at` is not part of the hash, so saving an unchanged configuration moves the timestamp and leaves the hash untouched - which distinguishes "redeployed, unchanged" from "edited". `config_hash` and `saved_at` in a PUT payload are ignored, so a GET response can be fed back into a PUT unedited.

There is no `created_at`: the PUT API replaces the whole document, so preserving a creation time would require a read-before-write or a scripted update, and "last touched" is the metric the housekeeping use case needs.

## Mapping version 4

`revision` and `saved_at` are added to the mappings of `.opensearch-querqy`. The three `update<n>To<n>` methods are replaced by a single migration that adds whichever properties are missing, which covers mapping versions 1, 2 and 3. Documents of earlier versions stay readable; they have no `revision`/`saved_at` until they are saved again.

Note (pre-existing behaviour, not introduced here): a node running an older plugin version rejects a document with an unknown mapping version, so rewriters should only be written once all nodes have been upgraded.

## Incidental fix

`RewriterConfigMapping.getConfigString` tested `getClass().isArray()` and then cast to `Iterable`, so a config that had been split across several values threw a `ClassCastException`. This never surfaced because such a config arrives as a `List` when the document is read from the index, but deriving the hash from an in-process document walks into it. It now handles `List` and `String[]`.

## Tests

200 tests pass. New coverage: hash determinism against property order, list order, class, info logging and revision; equality of hashes across mapping versions 3 and 4; configs that had to be split up; `saved_at` formatting, epoch-millis tolerance and its independence from the hash; PUT validation of `revision`; response serialization and REST route parsing; integration tests for reading single/listed rewriters, 404s and the empty index; and a new 3 -> 4 mapping migration test alongside the existing ones, renamed to `...1To4...` / `...2To4...`.
