### PR TITLE
Allow multiplicative boosts in CommonRules rewriter (#25)

### DIFF
--- a/src/main/java/querqy/opensearch/ConfigUtils.java
+++ b/src/main/java/querqy/opensearch/ConfigUtils.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.UnaryOperator;
 
 public interface ConfigUtils {
 
@@ -80,8 +81,14 @@ public interface ConfigUtils {
 
     static <T extends Enum<T>> Optional<T> getEnumArg(final Map<String, Object> config, final String name,
                                                       final Class<T> enumClass) {
+        return getEnumArg(config, name, enumClass, UnaryOperator.identity());
+    }
+
+    static <T extends Enum<T>> Optional<T> getEnumArg(final Map<String, Object> config, final String name,
+                                                      final Class<T> enumClass,
+                                                      final UnaryOperator<String> preprocessor) {
         final String value = (String) config.get(name);
-        return (value == null) ? Optional.empty() : Optional.of(Enum.valueOf(enumClass, value));
+        return (value == null) ? Optional.empty() : Optional.of(Enum.valueOf(enumClass, preprocessor.apply(value)));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/querqy/opensearch/rewriter/SimpleCommonRulesRewriterFactory.java
+++ b/src/main/java/querqy/opensearch/rewriter/SimpleCommonRulesRewriterFactory.java
@@ -44,6 +44,7 @@ public class SimpleCommonRulesRewriterFactory extends OpenSearchRewriterFactory 
     public static final String CONF_RHS_QUERY_PARSER = "querqyParser";
     public static final String CONF_RULES = "rules";
     public static final String CONF_LOOKUP_PREPROCESSOR = "lookupPreprocessor";
+    public static final String CONF_BOOST_METHOD = "boostMethod";
 
     private static final SelectionStrategyFactory DEFAULT_SELECTION_STRATEGY_FACTORY =
             new ExpressionCriteriaSelectionStrategyFactory();
@@ -51,6 +52,8 @@ public class SimpleCommonRulesRewriterFactory extends OpenSearchRewriterFactory 
     private static final QuerqyParserFactory DEFAULT_RHS_QUERY_PARSER = new WhiteSpaceQuerqyParserFactory();
 
     static final LookupPreprocessorType DEFAULT_LOOKUP_PREPROCESSOR_TYPE = LookupPreprocessorType.LOWERCASE;
+
+    static final BoostMethod DEFAULT_BOOST_METHOD = BoostMethod.ADDITIVE;
 
     private querqy.rewriter.commonrules.SimpleCommonRulesRewriterFactory delegate;
 
@@ -75,9 +78,13 @@ public class SimpleCommonRulesRewriterFactory extends OpenSearchRewriterFactory 
                 .map(LookupPreprocessorType::fromString)
                 .orElse(DEFAULT_LOOKUP_PREPROCESSOR_TYPE);
 
+        final BoostMethod boostMethod = ConfigUtils
+                .getEnumArg(config, CONF_BOOST_METHOD, BoostMethod.class, String::toUpperCase)
+                .orElse(DEFAULT_BOOST_METHOD);
+
         try {
             delegate = new querqy.rewriter.commonrules.SimpleCommonRulesRewriterFactory(rewriterId,
-                    new StringReader(rules), allowBooleanInput, BoostMethod.ADDITIVE,
+                    new StringReader(rules), allowBooleanInput, boostMethod,
                     querqyParser, selectionStrategyFactories,
                     DEFAULT_SELECTION_STRATEGY_FACTORY, false, lookupPreprocessorType);
         } catch (final IOException e) {
@@ -109,9 +116,19 @@ public class SimpleCommonRulesRewriterFactory extends OpenSearchRewriterFactory 
         final LookupPreprocessorType lookupPreprocessorType = lookupPreprocessorTypeName
                 .map(LookupPreprocessorType::fromString)
                 .orElse(DEFAULT_LOOKUP_PREPROCESSOR_TYPE);
+
+        final BoostMethod boostMethod;
+        try {
+            boostMethod = ConfigUtils
+                    .getEnumArg(config, CONF_BOOST_METHOD, BoostMethod.class, String::toUpperCase)
+                    .orElse(DEFAULT_BOOST_METHOD);
+        } catch (final Exception e) {
+            return Collections.singletonList("Invalid attribute 'boostMethod': " + e.getMessage());
+        }
+
         try {
             new querqy.rewriter.commonrules.SimpleCommonRulesRewriterFactory(rewriterId,
-                    new StringReader(rules), allowBooleanInput, BoostMethod.ADDITIVE,querqyParser,
+                    new StringReader(rules), allowBooleanInput, boostMethod, querqyParser,
                     Collections.emptyMap(),
                     DEFAULT_SELECTION_STRATEGY_FACTORY, false, lookupPreprocessorType);
         } catch (final IOException e) {

--- a/src/test/java/querqy/opensearch/rewriter/SimpleCommonRulesRewriterFactoryTest.java
+++ b/src/test/java/querqy/opensearch/rewriter/SimpleCommonRulesRewriterFactoryTest.java
@@ -22,6 +22,7 @@ import static java.util.Collections.singletonList;
 
 import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import querqy.opensearch.QuerqyProcessor;
 import querqy.opensearch.query.MatchingQuery;
@@ -31,6 +32,7 @@ import querqy.opensearch.rewriterstore.PutRewriterAction;
 import querqy.opensearch.rewriterstore.PutRewriterRequest;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
@@ -87,5 +89,61 @@ public class SimpleCommonRulesRewriterFactoryTest extends AbstractRewriterIntegr
 
     }
 
+    public void testMultiplicativeBoostMethodMultipliesTheScore() throws ExecutionException, InterruptedException {
+        indexDocs(
+                doc("id", "1", "field1", "a"),
+                doc("id", "2", "field1", "a", "field2", "b")
+        );
+
+        final Map<String, Object> content = new HashMap<>();
+        content.put("class", SimpleCommonRulesRewriterFactory.class.getName());
+
+        final Map<String, Object> config = new HashMap<>();
+        // mixed case on purpose: the boostMethod value must be matched case-insensitively
+        config.put("boostMethod", "Multiplicative");
+        config.put("rules", "a =>\nUP(3): *{\"term\": {\"field2\":\"b\"}}");
+        content.put("config", config);
+
+        final PutRewriterRequest request = new PutRewriterRequest("common_rules", content);
+
+        client().execute(PutRewriterAction.INSTANCE, request).get();
+
+        final QuerqyQueryBuilder querqyQuery = new QuerqyQueryBuilder(getInstanceFromNode(QuerqyProcessor.class));
+        querqyQuery.setRewriters(singletonList(new Rewriter("common_rules")));
+        querqyQuery.setMatchingQuery(new MatchingQuery("a"));
+        querqyQuery.setMinimumShouldMatch("1");
+        querqyQuery.setQueryFieldsAndBoostings(singletonList("field1"));
+
+        final SearchRequestBuilder searchRequestBuilder = client().prepareSearch(getIndexName());
+        searchRequestBuilder.setQuery(querqyQuery);
+
+        final SearchResponse response = client().search(searchRequestBuilder.request()).get();
+        final SearchHits hits = response.getHits();
+
+        assertEquals(2L, hits.getTotalHits().value());
+
+        final Map<String, Float> scoreById = new HashMap<>();
+        for (final SearchHit hit : hits.getHits()) {
+            scoreById.put((String) hit.getSourceAsMap().get("id"), hit.getScore());
+        }
+
+        // doc "1" and doc "2" have the same field1 content, so they get the same score from the main query.
+        // Doc "2" additionally matches the boost query on field2 and its score must be multiplied by the boost
+        // factor 3, not added to.
+        assertEquals(scoreById.get("1") * 3f, scoreById.get("2"), 0.001f);
+    }
+
+    public void testInvalidBoostMethodIsRejectedAsConfigurationError() {
+        final SimpleCommonRulesRewriterFactory factory = new SimpleCommonRulesRewriterFactory("common_rules");
+
+        final Map<String, Object> config = new HashMap<>();
+        config.put("boostMethod", "unknown");
+        config.put("rules", "a =>\nUP(3): b");
+
+        final List<String> errors = factory.validateConfiguration(config);
+        assertNotNull(errors);
+        assertEquals(1, errors.size());
+        assertTrue(errors.get(0).contains("boostMethod"));
+    }
 
 }


### PR DESCRIPTION
Closes #25

## Summary
- The OpenSearch `SimpleCommonRulesRewriterFactory` hardcoded `BoostMethod.ADDITIVE` even though `querqy-core`/`querqy-lucene` (already a dependency here) have supported multiplicative boosts since querqy/querqy#329.
- Adds a `boostMethod` config option (`ADDITIVE` default, or `MULTIPLICATIVE`), matched case-insensitively.
- Added a small overload to `ConfigUtils.getEnumArg` that takes a `String -> String` preprocessor (used here with `String::toUpperCase`), leaving the existing 3-arg overload's behavior unchanged for other callers.
- Invalid `boostMethod` values are caught in `validateConfiguration` and reported as a clean config error.

## Test plan
- [x] `SimpleCommonRulesRewriterFactoryTest#testMultiplicativeBoostMethodMultipliesTheScore` — verifies a `MULTIPLICATIVE` `UP(3)` rule multiplies (not adds to) the main query score, using a mixed-case `"Multiplicative"` value to confirm case-insensitivity.
- [x] `SimpleCommonRulesRewriterFactoryTest#testInvalidBoostMethodIsRejectedAsConfigurationError` — verifies an unknown `boostMethod` value is rejected with a descriptive error.
- [x] Full `./gradlew test` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
